### PR TITLE
config, commands, rpc, test update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _testmain.go
 go.sum
 go/
 multi-signer-controler
+*.conf

--- a/cmd.go
+++ b/cmd.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+    "fmt"
+)
+
+type CmdFunc func(args []string, remote bool, output *[]string) error
+
+var Command = make(map[string]CmdFunc)
+var CommandHelp = make(map[string]string)
+
+var ErrNoRemoteCall = fmt.Errorf("Can not be called remotely")

--- a/config.go
+++ b/config.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+    "encoding/json"
+    "io/ioutil"
+    "sync"
+)
+
+type config struct {
+    m sync.RWMutex
+
+    conf map[string]string
+
+    changed bool
+}
+
+var Config = NewConfig()
+
+func NewConfig() *config {
+    return &config{
+        conf: make(map[string]string),
+    }
+}
+
+func (c *config) Get(name, _default string) string {
+    c.m.RLock()
+    defer c.m.RUnlock()
+
+    v, ok := c.conf[name]
+    if !ok {
+        return _default
+    }
+    return v
+}
+
+func (c *config) Set(name, value string) {
+    c.m.Lock()
+    defer c.m.Unlock()
+
+    c.conf[name] = value
+
+    c.changed = true
+}
+
+func (c *config) Store(filename string) error {
+    c.m.Lock()
+    defer c.m.Unlock()
+
+    if !c.changed {
+        return nil
+    }
+
+    b, err := json.Marshal(c.conf)
+    if err != nil {
+        return err
+    }
+
+    err = ioutil.WriteFile(filename, b, 0644)
+    if err != nil {
+        return err
+    }
+
+    c.changed = false
+
+    return nil
+}
+
+func (c *config) Load(filename string) error {
+    c.m.Lock()
+    defer c.m.Unlock()
+
+    b, err := ioutil.ReadFile(filename)
+    if err != nil {
+        return err
+    }
+
+    conf := make(map[string]string)
+
+    err = json.Unmarshal(b, &conf)
+    if err != nil {
+        return err
+    }
+
+    c.conf = conf
+
+    return nil
+}

--- a/config_cmd.go
+++ b/config_cmd.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+    "fmt"
+)
+
+func init() {
+    Command["conf-list"] = ConfigListCmd
+    CommandHelp["conf-list"] = "List all configure options and their value"
+
+    Command["conf-set"] = ConfigSetCmd
+    CommandHelp["conf-set"] = "Set a config option, requires <name> <value>"
+}
+
+func ConfigListCmd(args []string, remote bool, output *[]string) error {
+    Config.m.RLock()
+    defer Config.m.RUnlock()
+
+    *output = append(*output, "Config:")
+    for k, v := range Config.conf {
+        *output = append(*output, fmt.Sprintf("  %s: %v", k, v))
+    }
+
+    return nil
+}
+
+func ConfigSetCmd(args []string, remote bool, output *[]string) error {
+    if len(args) < 2 {
+        return fmt.Errorf("Missing <name> <value>")
+    }
+
+    Config.Set(args[0], args[1])
+
+    *output = append(*output, fmt.Sprintf("Config %s set", args[0]))
+
+    return nil
+}

--- a/daemon_cmd.go
+++ b/daemon_cmd.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+    "fmt"
+    "log"
+    "net"
+    "net/http"
+    "net/rpc"
+)
+
+type Rpc struct {
+}
+
+func (r *Rpc) Call(args []string, reply *[]string) error {
+    cmd, ok := Command[args[0]]
+    if !ok {
+        log.Println("Invalid call:", args[0])
+        return fmt.Errorf("Command does not exist: ", args[0])
+    }
+
+    log.Println("Calling command", args[0])
+    if err := cmd(args[1:], true, reply); err != nil {
+        return fmt.Errorf("Command ", args[0], " error: ", err)
+    }
+
+    return nil
+}
+
+func init() {
+    Command["daemon"] = DaemonCmd
+    CommandHelp["daemon"] = "Run the daemon and listen for RPC, requires: [server|ip]:port"
+}
+
+func DaemonCmd(args []string, remote bool, output *[]string) error {
+    if remote {
+        return ErrNoRemoteCall
+    }
+
+    if len(args) < 1 {
+        return fmt.Errorf("server/ip and port for RPC required")
+    }
+
+    r := new(Rpc)
+    rpc.Register(r)
+    rpc.HandleHTTP()
+    l, e := net.Listen("tcp", args[0])
+    if e != nil {
+        return fmt.Errorf("listen error:", e)
+    }
+    log.Println("Listening for RPC on", l.Addr().String())
+    http.Serve(l, nil)
+
+    return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,6 @@ module github.com/DNSSEC-Provisioning/multi-signer-controler
 go 1.15
 
 require (
+	github.com/google/uuid v1.2.0
 	github.com/miekg/dns v1.1.35
 )

--- a/help_cmd.go
+++ b/help_cmd.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+    "log"
+    "sort"
+)
+
+func init() {
+    Command["help"] = HelpCmd
+}
+
+func HelpCmd(args []string, remote bool, output *[]string) error {
+    if remote {
+        return ErrNoRemoteCall
+    }
+
+    log.Println("Available commands:")
+    cmds := []string{}
+    for k, _ := range CommandHelp {
+        if k == "help" {
+            continue
+        }
+        cmds = append(cmds, k)
+    }
+    sort.Strings(cmds)
+    for _, k := range cmds {
+        log.Printf("  %s: %s", k, CommandHelp[k])
+    }
+    log.Println("  help: Show this help and exit")
+
+    return nil
+}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,9 @@ package main
 import (
     "flag"
     "log"
+    "net/rpc"
     "os"
+    "os/signal"
     "runtime"
     "runtime/pprof"
     "time"
@@ -11,6 +13,8 @@ import (
 
 var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
 var memstats = flag.Bool("memstats", false, "output memstats")
+var conf = flag.String("conf", "", "config file to use")
+var remote = flag.String("remote", "", "specify remote daemon to execute commands on [<server|ip>]:<port>")
 
 func main() {
     flag.Parse()
@@ -56,5 +60,75 @@ func main() {
 }
 
 func run() int {
+    args := flag.Args()
+
+    if len(args) < 1 {
+        log.Println("At least one command must be given")
+        HelpCmd([]string{}, false, nil)
+        return 1
+    }
+
+    if args[0] == "help" {
+        HelpCmd([]string{}, false, nil)
+        return 0
+    }
+
+    if *remote != "" {
+        client, err := rpc.DialHTTP("tcp", *remote)
+        if err != nil {
+            log.Fatal("dialing:", err)
+        }
+        defer client.Close()
+
+        var reply []string
+        err = client.Call("Rpc.Call", args, &reply)
+        if err != nil {
+            log.Fatal("call error:", err)
+        }
+
+        for _, v := range reply {
+            log.Println(v)
+        }
+        return 0
+    }
+
+    if *conf == "" {
+        log.Fatal("-conf <file> must be specified")
+    }
+    if _, err := os.Stat(*conf); !os.IsNotExist(err) {
+        log.Println("Loading config", *conf)
+        if err := Config.Load(*conf); err != nil {
+            log.Fatal(err)
+        }
+    }
+
+    c := make(chan os.Signal, 1)
+    signal.Notify(c, os.Interrupt)
+    go func() {
+        for range c {
+            log.Println("Caught SIGINT")
+
+            if err := Config.Store(*conf); err != nil {
+                log.Fatal(err)
+            }
+
+            os.Exit(1)
+        }
+    }()
+
+    cmd, ok := Command[args[0]]
+    if !ok {
+        log.Fatal("Command does not exist: ", args[0])
+    }
+
+    var out []string
+    if err := cmd(args[1:], false, &out); err != nil {
+        log.Fatal("Command ", args[0], " error: ", err)
+    }
+
+    for _, v := range out {
+        log.Println(v)
+    }
+
     return 0
 }

--- a/test_update_cmd.go
+++ b/test_update_cmd.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+    "encoding/base32"
+    "fmt"
+    "github.com/google/uuid"
+    "github.com/miekg/dns"
+    "strings"
+    "time"
+)
+
+func init() {
+    Command["test-update"] = TestUpdateCmd
+    CommandHelp["test-update"] = "Test if dynamic update work by inserting and removing a TXT record, requires <DNS server> <zone> <TSIG key>"
+}
+
+func TestUpdateCmd(args []string, remote bool, output *[]string) error {
+    if len(args) < 3 {
+        return fmt.Errorf("Missing <DNS server> <zone> <TSIG key>")
+    }
+    server := args[0]
+    zone := args[1]
+    tsigkey := args[2]
+
+    secret := Config.Get("tsigkey-"+tsigkey, "")
+    if secret == "" {
+        return fmt.Errorf("Missing TSIG key %s, use conf-set tsigkey-<name> <secret>", tsigkey)
+    }
+
+    b := uuid.New()
+    id := base32.HexEncoding.EncodeToString(b[:])
+    id = strings.ToLower(strings.Replace(id, "=", "", -1))
+
+    rr := new(dns.TXT)
+    rr.Hdr = dns.RR_Header{Name: id + "." + zone, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 3600}
+    rr.Txt = []string{"test-update"}
+    rrs := []dns.RR{rr}
+
+    m := new(dns.Msg)
+    m.SetUpdate(zone)
+    m.Insert(rrs)
+    m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
+
+    *output = append(*output, m.String())
+
+    c := new(dns.Client)
+    c.TsigSecret = map[string]string{"update.": secret}
+    in, rtt, err := c.Exchange(m, server)
+    if err != nil {
+        return err
+    }
+
+    *output = append(*output, fmt.Sprintf("Insert took %v", rtt))
+    *output = append(*output, in.String())
+
+    m = new(dns.Msg)
+    m.SetUpdate(zone)
+    m.Remove(rrs)
+    m.SetTsig("update.", dns.HmacSHA256, 300, time.Now().Unix())
+
+    *output = append(*output, m.String())
+
+    in, rtt, err = c.Exchange(m, server)
+    if err != nil {
+        return err
+    }
+
+    *output = append(*output, fmt.Sprintf("Remove took %v", rtt))
+    *output = append(*output, in.String())
+
+    return nil
+}


### PR DESCRIPTION
- Add config facility, `-conf`, load/store in JSON
- Add commands facility
- Add `help` command
- Add `conf-list` command
- Add `conf-set` command
- Add `daemon` command
- Add `-remote` option to run command over RPC
- Add `test-update` command