### PR TITLE
hmac, config, signer TSIG, fmt, sync, test

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ export PATH="$PATH:$GOROOT"
 make
 ./multi-signer-controler
 ```
+
+# Known Issues
+
+- TSIG keys hardcoded to HMAC-SHA256

--- a/group_cmd.go
+++ b/group_cmd.go
@@ -44,7 +44,7 @@ func GroupRemoveCmd(args []string, remote bool, output *[]string) error {
         return fmt.Errorf("requires <fqdn>")
     }
 
-    if Config.Exists(fmt.Sprintf("signers:%s", args[0])) {
+    if Config.Exists("signers:" + args[0]) {
         return fmt.Errorf("group %s has signers", args[0])
     }
 

--- a/main.go
+++ b/main.go
@@ -130,5 +130,9 @@ func run() int {
         log.Println(v)
     }
 
+    if err := Config.Store(*conf); err != nil {
+        log.Fatal(err)
+    }
+
     return 0
 }

--- a/signer_cmd.go
+++ b/signer_cmd.go
@@ -8,10 +8,12 @@ func init() {
     Command["signer-add"] = SignerAddCmd
     Command["signer-list"] = SignerListCmd
     Command["signer-remove"] = SignerRemoveCmd
+    Command["signer-tsig"] = SignerTsigCmd
 
-    CommandHelp["signer-add"] = "Add a signer to a group, requires <group>, <name>, <ip|host> [port]"
+    CommandHelp["signer-add"] = "Add a signer to a group, requires <group> <name> <ip|host> [port]"
     CommandHelp["signer-list"] = "List signers in a group, requires <group>"
-    CommandHelp["signer-remove"] = "Remove signer from a group, requires <group>, <name>"
+    CommandHelp["signer-remove"] = "Remove signer from a group, requires <group> <name>"
+    CommandHelp["signer-tsig"] = "Set or show which TSIG key to use for dynamic updates, requires <name> [TSIG key]"
 }
 
 func SignerAddCmd(args []string, remote bool, output *[]string) error {
@@ -28,12 +30,12 @@ func SignerAddCmd(args []string, remote bool, output *[]string) error {
         return fmt.Errorf("group %s does not exist", args[0])
     }
 
-    if Config.Exists(fmt.Sprintf("signer:%s", args[1])) {
+    if Config.Exists("signer:" + args[1]) {
         return fmt.Errorf("signer %s already exists", args[1])
     }
 
-    Config.Set(fmt.Sprintf("signer:%s", args[1]), args[2])
-    Config.ListAdd(fmt.Sprintf("signers:%s", args[0]), args[1], false)
+    Config.Set("signer:"+args[1], args[2])
+    Config.ListAdd("signers:"+args[0], args[1], false)
 
     *output = append(*output, fmt.Sprintf("Signer %s added", args[1]))
 
@@ -45,10 +47,10 @@ func SignerListCmd(args []string, remote bool, output *[]string) error {
         return fmt.Errorf("requires <group>")
     }
 
-    l := Config.ListGet(fmt.Sprintf("signers:%s", args[0]))
+    l := Config.ListGet("signers:" + args[0])
     *output = append(*output, fmt.Sprintf("Signers in %s:", args[0]))
     for _, v := range l {
-        ip := Config.Get(fmt.Sprintf("signer:%s", v), "")
+        ip := Config.Get("signer:"+v, "")
         *output = append(*output, fmt.Sprintf("  %s %s", v, ip))
     }
 
@@ -60,14 +62,42 @@ func SignerRemoveCmd(args []string, remote bool, output *[]string) error {
         return fmt.Errorf("requires <group> <name>")
     }
 
-    if !Config.Exists(fmt.Sprintf("signer:%s", args[1])) {
+    if !Config.Exists("signer:" + args[1]) {
         return fmt.Errorf("signer %s does not exists", args[1])
     }
 
-    Config.ListRemove(fmt.Sprintf("signers:%s", args[1]), args[0])
-    Config.Remove(fmt.Sprintf("signer:%s", args[0]))
+    Config.ListRemove("signers:"+args[1], args[0])
+    Config.Remove("signer:" + args[0])
 
     *output = append(*output, fmt.Sprintf("Signer %s removed", args[1]))
+
+    return nil
+}
+
+func SignerTsigCmd(args []string, remote bool, output *[]string) error {
+    if len(args) < 1 {
+        return fmt.Errorf("requires <name> [TSIG key]")
+    }
+
+    if !Config.Exists("signer:" + args[0]) {
+        return fmt.Errorf("signer %s does not exist", args[0])
+    }
+
+    if len(args) > 1 {
+        if !Config.Exists("tsigkey-" + args[1]) {
+            return fmt.Errorf("TSIG key does not exist, use conf-set tsigkey-%s <secret>", args[1])
+        }
+
+        Config.Set("signer-tsigkey:"+args[0], args[1])
+        *output = append(*output, fmt.Sprintf("Signer %s set to use TSIG key %s for dynamic updates", args[0], args[1]))
+    } else {
+        key := Config.Get("signer-tsigkey:"+args[0], "")
+        if key == "" {
+            *output = append(*output, fmt.Sprintf("Signer %s has no TSIG key configured", args[0]))
+        } else {
+            *output = append(*output, fmt.Sprintf("Signer %s is using TSIG key %s for dynamic updates", args[0], key))
+        }
+    }
 
     return nil
 }

--- a/test_update_cmd.go
+++ b/test_update_cmd.go
@@ -45,7 +45,7 @@ func TestUpdateCmd(args []string, remote bool, output *[]string) error {
     *output = append(*output, m.String())
 
     c := new(dns.Client)
-    c.TsigSecret = map[string]string{"update.": secret}
+    c.TsigSecret = map[string]string{tsigkey + ".": secret}
     in, rtt, err := c.Exchange(m, server)
     if err != nil {
         return err


### PR DESCRIPTION
- Add know issues, TSIG hardcoded to HMAC-SHA256 (for now)
- `config`: Fix storing config on exit when using commands
- Add `signer-tsig` to set what TSIG key to use for that signer on dynamic updates
- Clean up unneeded `fmt.Sprintf()`
- Add `sync-dnskey` to sync DNSKEYs between signers in a group
- `test-update`: Fix TSIG key usage