### PR TITLE
Automation

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -1,0 +1,568 @@
+# Run Examples
+
+These examples are all based on `msat1.catch22.se.`, where two PowerDNS
+signers (`msg1`, `msg2`) are used and updated using dynamic updates.
+
+At first the group is setup to use a single signer `msg1`, then we add
+and join `msg2`, go over each step in the automation for it to completely
+join.
+
+Then `msg2` is marked as leaving, go over each step in the automation for it
+to completely leave and once done it will be removed from the group.
+
+To simplify, set a short-cut for the base of the command for these examples:
+
+```
+CMD="./multi-signer-controller -conf example.conf"
+```
+
+## Zone data on setup
+
+On `msg1`:
+```
+$ORIGIN .
+msat1.catch22.se	3600	IN	MX	0 .
+msat1.catch22.se	3600	IN	NS	ns1.msg1.catch22.se.
+msat1.catch22.se	3600	IN	SOA	msat1.catch22.se hostmaster.msat1.catch22.se 2021061712 300 300 86400 300
+msat1.catch22.se	3600	IN	TXT	"v=spf1 -all"
+whoami.msat1.catch22.se	3600	IN	TXT	"ns1.msg1.catch22.se Group 1"
+```
+
+On `msg2`:
+```
+$ORIGIN .
+msat1.catch22.se	3600	IN	MX	0 .
+msat1.catch22.se	3600	IN	NS	ns1.msg2.catch22.se.
+msat1.catch22.se	3600	IN	SOA	msat1.catch22.se hostmaster.msat1.catch22.se 101 300 300 86400 300
+msat1.catch22.se	3600	IN	TXT	"v=spf1 -all"
+whoami.msat1.catch22.se	3600	IN	TXT	"ns1.msg2.catch22.se Group 1"
+```
+
+On `parent`:
+```
+[catch22.se.] msat1.catch22.se. 300 NS ns1.msg1.catch22.se.
+[catch22.se.] msat1.catch22.se. 600 DS 38959 13 2 ...
+[catch22.se.] msat1.catch22.se. 600 RRSIG DS 13 3 600 20210701090328 20210617073328 36915 catch22.se. ...
+[catch22.se.] msat1.catch22.se. 7200 RRSIG NSEC 13 3 7200 20210629065851 20210615052851 36915 catch22.se. ...
+[catch22.se.] msat1.catch22.se. 7200 NSEC msg1.catch22.se. NS DS RRSIG NSEC
+```
+
+## No daemon, step automation
+
+First we add the group:
+```
+$CMD group-add msat1.catch22.se. 13.48.238.90
+...
+2021/06/17 14:48:22 Group msat1.catch22.se. added
+```
+
+Next we add the first signer, note that we add the TSIG keys first so that
+they exists prior of the signer:
+```
+$CMD conf-set tsigkey-msat1tsig1 ...tsig-secret...
+$CMD conf-set signer-tsigkey:msg1 msat1tsig1
+$CMD signer-add msat1.catch22.se. msg1 ns1.msg1.catch22.se. 13.53.206.47
+...
+2021/06/17 14:49:44 Signer msg1 added
+```
+
+Now we add the next signer and this will be the one joining the group,
+note how automation stage changed:
+```
+$CMD conf-set tsigkey-msat1tsig2 ...tsig-secret...
+$CMD conf-set signer-tsigkey:msg2 msat1tsig2
+$CMD signer-add msat1.catch22.se. msg2 ns1.msg2.catch22.se. 13.53.34.31
+...
+2021/06/17 14:55:12 Signer msg2 added
+2021/06/17 14:55:12 Automation for msat1.catch22.se. now join-sync-dnskeys
+```
+
+Now we can run `status` to just check that it can query all server, don't
+worry about all the "missing" right now but look at what it found in `msg1`,
+`msg2` and the parent:
+```
+$CMD status msat1.catch22.se.
+
+2021/06/17 14:56:32 Loading config example.conf
+2021/06/17 14:56:32 msg1: found DNSKEY 257 3 13 nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 14:56:32 msg1: found DNSKEY 256 3 13 cVsbobWK6RCkVVdmhisDNgor0oRsYyjhv300B9Xdfx7j+WOuAjEEbvt08sAU7u+DSpHE88t8+SGDoefO3DvufQ==
+2021/06/17 14:56:32 msg1: found NS ns1.msg1.catch22.se.
+2021/06/17 14:56:32 msg2: found DNSKEY 257 3 13 oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 14:56:32 msg2: found DNSKEY 256 3 13 Hmva5+2gzldmznimU5dYnIKYUHAwmROXhrqcxS33eiE2VEnWDJWCrwjjTVxtPzQzcrEXUm4qfx+AqCZR1zVQdw==
+2021/06/17 14:56:32 msg2: found NS ns1.msg2.catch22.se.
+2021/06/17 14:56:32 Check sync status of msg1 DNSKEYs
+2021/06/17 14:56:32 DNSKEY missing in msg2: cVsbobWK6RCkVVdmhisDNgor0oRsYyjhv300B9Xdfx7j+WOuAjEEbvt08sAU7u+DSpHE88t8+SGDoefO3DvufQ==
+2021/06/17 14:56:32 Check sync status of msg2 DNSKEYs
+2021/06/17 14:56:32 DNSKEY missing in msg1: Hmva5+2gzldmznimU5dYnIKYUHAwmROXhrqcxS33eiE2VEnWDJWCrwjjTVxtPzQzcrEXUm4qfx+AqCZR1zVQdw==
+2021/06/17 14:56:32 Check sync status of msg1 CDSes
+2021/06/17 14:56:32 CDS missing for KSK: nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 14:56:32 CDS missing for KSK: oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 14:56:32 Check sync status of msg2 CDSes
+2021/06/17 14:56:32 CDS missing for KSK: nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 14:56:32 CDS missing for KSK: oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 14:56:32 Check sync status of msg1 CDNSKEYs
+2021/06/17 14:56:32 CDNSKEY missing for KSK: nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 14:56:32 CDNSKEY missing for KSK: oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 14:56:32 Check sync status of msg2 CDNSKEYs
+2021/06/17 14:56:32 CDNSKEY missing for KSK: nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 14:56:32 CDNSKEY missing for KSK: oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 14:56:32 Check sync status of msg1 NSes
+2021/06/17 14:56:32 NS missing: ns1.msg2.catch22.se.
+2021/06/17 14:56:32 Check sync status of msg2 NSes
+2021/06/17 14:56:32 NS missing: ns1.msg1.catch22.se.
+2021/06/17 14:56:32 Check sync status of NSes for leaving signers
+2021/06/17 14:56:32 Check sync status of parent 13.48.238.90:53
+2021/06/17 14:56:32   found DS 38959 13 2 ce45ee0f2869965a7ec55140d662c7469ea41d50028fbeed6fe1e2f2f92e5ac2
+2021/06/17 14:56:32   DS needs removal: 38959 13 2 ce45ee0f2869965a7ec55140d662c7469ea41d50028fbeed6fe1e2f2f92e5ac2
+2021/06/17 14:56:32   found NS ns1.msg1.catch22.se.
+2021/06/17 14:56:32   Missing NS: ns1.msg2.catch22.se.
+```
+
+Next is to start stepping through the automation:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 14:57:23 Syncing msg1 DNSKEYs
+2021/06/17 14:57:23 - cVsbobWK6RCkVVdmhisDNgor0oRsYyjhv300B9Xdfx7j+WOuAjEEbvt08sAU7u+DSpHE88t8+SGDoefO3DvufQ==
+2021/06/17 14:57:23 nsupdate: Sending inserts 1, removals 0 to signer msg2
+2021/06/17 14:57:23 nsupdate: Update took 27.909242ms, rcode NOERROR
+2021/06/17 14:57:23   Added DNSKEY to msg2
+2021/06/17 14:57:23 Syncing msg2 DNSKEYs
+2021/06/17 14:57:23 - Hmva5+2gzldmznimU5dYnIKYUHAwmROXhrqcxS33eiE2VEnWDJWCrwjjTVxtPzQzcrEXUm4qfx+AqCZR1zVQdw==
+2021/06/17 14:57:23 nsupdate: Sending inserts 1, removals 0 to signer msg1
+2021/06/17 14:57:23 nsupdate: Update took 30.35987ms, rcode NOERROR
+2021/06/17 14:57:23   Added DNSKEY to msg1
+2021/06/17 14:57:23 Automate step join-sync-dnskeys success, next stage join-dnskeys-synced
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 14:59:59 Automate step join-dnskeys-synced success, next stage join-sync-cdscdnskeys
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:00:16 nsupdate: Sending inserts 4, removals 0 to signer msg1
+2021/06/17 15:00:16 nsupdate: Update took 31.181046ms, rcode NOERROR
+2021/06/17 15:00:16   Added CDS/CDNSKEYs to msg1
+2021/06/17 15:00:16 nsupdate: Sending inserts 4, removals 0 to signer msg2
+2021/06/17 15:00:16 nsupdate: Update took 29.614732ms, rcode NOERROR
+2021/06/17 15:00:16   Added CDS/CDNSKEYs to msg2
+2021/06/17 15:00:16 Automate step join-sync-cdscdnskeys success, next stage join-cdscdnskeys-synced
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:00:26 Automate step join-cdscdnskeys-synced success, next stage join-parent-ds-synced
+```
+
+At this stage the parent needs to scan for the CDS/CDNSKEY records and
+update it's DS records. This can also be done manually to progress the
+automation.
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:00:39 Parent DS not synced yet for msat1.catch22.se.
+```
+
+Once the parent's DS records are updated the automation will continue:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:02:30 Automate step join-parent-ds-synced success, next stage join-remove-cdscdnskeys
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:02:46 nsupdate: Sending remove rrset(s) 2 to signer msg1
+2021/06/17 15:02:46 nsupdate: Update took 26.615852ms, rcode NOERROR
+2021/06/17 15:02:46   Removed CDS/CDNSKEYs from msg1
+2021/06/17 15:02:46 nsupdate: Sending remove rrset(s) 2 to signer msg2
+2021/06/17 15:02:46 nsupdate: Update took 27.193629ms, rcode NOERROR
+2021/06/17 15:02:46   Removed CDS/CDNSKEYs from msg2
+2021/06/17 15:02:46 Automate step join-remove-cdscdnskeys success, next stage join-wait-ds
+```
+
+Now we need to wait maximum DS TTL * 2:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:02:55 Wait until 2021-06-17 15:22:55 +0200 CEST (19m59.98980194s)
+```
+
+This step can be fast-forwarded by changing the until date:
+```
+$CMD conf-get group-wait-ds:msat1.catch22.se.
+...
+2021/06/17 15:03:53 Config group-wait-ds:msat1.catch22.se.: 2021-06-17T15:22:55+02:00
+
+$CMD conf-set group-wait-ds:msat1.catch22.se. 2021-06-17T15:02:55+02:00
+...
+2021/06/17 15:04:09 Config group-wait-ds:msat1.catch22.se. set
+```
+
+The waiting time has passed:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:04:33 Automate step join-wait-ds success, next stage join-sync-nses
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:04:44 nsupdate: Sending inserts 2, removals 0 to signer msg1
+2021/06/17 15:04:44 nsupdate: Update took 20.837498ms, rcode NOERROR
+2021/06/17 15:04:44   Add/rem'ed NSes to msg1
+2021/06/17 15:04:44 nsupdate: Sending inserts 2, removals 0 to signer msg2
+2021/06/17 15:04:44 nsupdate: Update took 24.628736ms, rcode NOERROR
+2021/06/17 15:04:44   Add/rem'ed NSes to msg2
+2021/06/17 15:04:44 Automate step join-sync-nses success, next stage join-nses-synced
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:04:54 Automate step join-nses-synced success, next stage join-add-csync
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:05:09 nsupdate: Sending inserts 1, removals 0 to signer msg1
+2021/06/17 15:05:09 nsupdate: Update took 22.172967ms, rcode NOERROR
+2021/06/17 15:05:09   Added CSYNC to msg1
+2021/06/17 15:05:09 nsupdate: Sending inserts 1, removals 0 to signer msg2
+2021/06/17 15:05:09 nsupdate: Update took 27.084435ms, rcode NOERROR
+2021/06/17 15:05:09   Added CSYNC to msg2
+2021/06/17 15:05:09 Automate step join-add-csync success, next stage join-parent-ns-synced
+```
+
+At this stage the parent needs to update NS records based on CSYNC. This
+can also be done manually to progress the automation.
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:05:18 Parent NS not synced yet for msat1.catch22.se.
+```
+
+Once the parent's NS records are updated the automation will continue:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:05:50 Automate step join-parent-ns-synced success, next stage join-remove-csync
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:06:01 nsupdate: Sending remove rrset(s) 1 to signer msg1
+2021/06/17 15:06:01 nsupdate: Update took 26.236728ms, rcode NOERROR
+2021/06/17 15:06:01   Removed CSYNC from msg1
+2021/06/17 15:06:01 nsupdate: Sending remove rrset(s) 1 to signer msg2
+2021/06/17 15:06:01 nsupdate: Update took 29.221394ms, rcode NOERROR
+2021/06/17 15:06:01   Removed CSYNC from msg2
+2021/06/17 15:06:01 Automate step join-remove-csync success, next stage ready
+```
+
+At this point the group is in ready state and both signers has joined to
+multi-signer group.
+
+If you run the automation again you'll see that there is nothing to do:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:21:09 Nothing to do for msat1.catch22.se.
+```
+
+We will now mark `msg2` as a leaving signer and the automation will change:
+
+```
+$CMD signer-mark-leave msg2
+...
+2021/06/17 15:22:17 Signer msg2 now marked as leaving
+2021/06/17 15:22:17 Automation for msat1.catch22.se. now leave-sync-nses
+```
+
+Let's step through the automation:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:22:49 removing ns1.msg2.catch22.se., leaving signer
+2021/06/17 15:22:49 nsupdate: Sending inserts 1, removals 1 to signer msg1
+2021/06/17 15:22:49 nsupdate: Update took 29.517875ms, rcode NOERROR
+2021/06/17 15:22:49   Add/rem'ed NSes to msg1
+2021/06/17 15:22:49 nsupdate: Sending inserts 1, removals 1 to signer msg2
+2021/06/17 15:22:49 nsupdate: Update took 28.021756ms, rcode NOERROR
+2021/06/17 15:22:49   Add/rem'ed NSes to msg2
+2021/06/17 15:22:49 Automate step leave-sync-nses success, next stage leave-nses-synced
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:22:55 Automate step leave-nses-synced success, next stage leave-add-csync
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:23:00 nsupdate: Sending inserts 1, removals 0 to signer msg1
+2021/06/17 15:23:00 nsupdate: Update took 25.280774ms, rcode NOERROR
+2021/06/17 15:23:00   Added CSYNC to msg1
+2021/06/17 15:23:00 nsupdate: Sending inserts 1, removals 0 to signer msg2
+2021/06/17 15:23:00 nsupdate: Update took 29.01913ms, rcode NOERROR
+2021/06/17 15:23:00   Added CSYNC to msg2
+2021/06/17 15:23:00 Automate step leave-add-csync success, next stage leave-parent-ns-synced
+```
+
+Once again we need to wait or manually update the parent's NS records:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:23:03 Parent NS not synced yet for msat1.catch22.se.
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:24:06 Automate step leave-parent-ns-synced success, next stage leave-remove-csync
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:24:10 nsupdate: Sending remove rrset(s) 1 to signer msg1
+2021/06/17 15:24:10 nsupdate: Update took 28.351098ms, rcode NOERROR
+2021/06/17 15:24:10   Removed CSYNC from msg1
+2021/06/17 15:24:10 nsupdate: Sending remove rrset(s) 1 to signer msg2
+2021/06/17 15:24:10 nsupdate: Update took 23.873898ms, rcode NOERROR
+2021/06/17 15:24:10   Removed CSYNC from msg2
+2021/06/17 15:24:10 Automate step leave-remove-csync success, next stage leave-wait-ns
+```
+
+We wait maximum NS TTL * 2:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:24:12 Wait until 2021-06-17 17:24:12 +0200 CEST (1h59m59.315906269s)
+```
+
+Or fast-forward the automation:
+```
+$CMD conf-get group-wait-ns:msat1.catch22.se.
+...
+2021/06/17 15:24:23 Config group-wait-ns:msat1.catch22.se.: 2021-06-17T17:24:12+02:00
+
+$CMD conf-set group-wait-ns:msat1.catch22.se. 2021-06-17T15:24:12+02:00
+...
+2021/06/17 15:24:41 Config group-wait-ns:msat1.catch22.se. set
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:24:44 Automate step leave-wait-ns success, next stage leave-sync-dnskeys
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:24:45 Syncing msg1 DNSKEYs
+2021/06/17 15:24:45 - cVsbobWK6RCkVVdmhisDNgor0oRsYyjhv300B9Xdfx7j+WOuAjEEbvt08sAU7u+DSpHE88t8+SGDoefO3DvufQ==
+2021/06/17 15:24:45 - Hmva5+2gzldmznimU5dYnIKYUHAwmROXhrqcxS33eiE2VEnWDJWCrwjjTVxtPzQzcrEXUm4qfx+AqCZR1zVQdw==
+2021/06/17 15:24:45 Signer msg2 is leaving, removing it's DNSKEYs from others
+2021/06/17 15:24:45 - Hmva5+2gzldmznimU5dYnIKYUHAwmROXhrqcxS33eiE2VEnWDJWCrwjjTVxtPzQzcrEXUm4qfx+AqCZR1zVQdw==
+2021/06/17 15:24:45 nsupdate: Sending inserts 0, removals 1 to signer msg1
+2021/06/17 15:24:45 nsupdate: Update took 20.755376ms, rcode NOERROR
+2021/06/17 15:24:45   Removed DNSKEY from msg1
+2021/06/17 15:24:45 Automate step leave-sync-dnskeys success, next stage leave-dnskeys-synced
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:24:48 Automate step leave-dnskeys-synced success, next stage leave-sync-cdscdnskeys
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:24:51 nsupdate: Sending inserts 2, removals 0 to signer msg1
+2021/06/17 15:24:51 nsupdate: Update took 29.548505ms, rcode NOERROR
+2021/06/17 15:24:51   Added CD/CDNSKEYs to msg1
+2021/06/17 15:24:51 Automate step leave-sync-cdscdnskeys success, next stage leave-cdscdnskeys-synced
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:25:01 Automate step leave-cdscdnskeys-synced success, next stage leave-parent-ds-synced
+```
+
+And now we need to update the parent's DS records:
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:25:06 Parent DS not synced yet for msat1.catch22.se.
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:25:24 Automate step leave-parent-ds-synced success, next stage leave-remove-cdscdnskeys
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:25:25 nsupdate: Sending remove rrset(s) 2 to signer msg1
+2021/06/17 15:25:25 nsupdate: Update took 21.015897ms, rcode NOERROR
+2021/06/17 15:25:25   Removed CD/CDNSKEYs from msg1
+2021/06/17 15:25:25 nsupdate: Sending remove rrset(s) 2 to signer msg2
+2021/06/17 15:25:25 nsupdate: Update took 16.313781ms, rcode NOERROR
+2021/06/17 15:25:25   Removed CD/CDNSKEYs from msg2
+2021/06/17 15:25:25 Automate step leave-remove-cdscdnskeys success, next stage ready
+```
+
+```
+$CMD automate-step msat1.catch22.se.
+...
+2021/06/17 15:25:26 Nothing to do for msat1.catch22.se.
+```
+
+Finally `msg2` has been phased out from the group and can be removed:
+```
+$CMD signer-remove msg2
+...
+2021/06/17 15:25:54 Signer msg2 removed
+```
+
+## Daemon, full automation
+
+For full automation we will run the daemon and send all commands over an
+gRPC, so we need to update the short-cut:
+
+```
+CMD="./multi-signer-controller -conf example2.conf -remote 127.0.0.1:5353"
+```
+Note the usage of a new configuration file.
+
+Now we start the daemon with the HTTP status service (use an IP/port you can connect to):
+```
+./multi-signer-controller -conf example2.conf -http 127.0.0.1:8080 daemon 127.0.0.1:5353
+```
+
+Open a browser to the HTTP address so you can view the console.
+
+Then we add the group:
+```
+$CMD group-add msat1.catch22.se. 13.48.238.90
+...
+2021/06/17 15:38:34 Group msat1.catch22.se. added
+```
+
+Next we add the first signer, note that we add the TSIG keys first so that
+they exists prior of the signer:
+```
+$CMD conf-set tsigkey-msat1tsig1 ...tsig-secret...
+$CMD conf-set signer-tsigkey:msg1 msat1tsig1
+$CMD signer-add msat1.catch22.se. msg1 ns1.msg1.catch22.se. 13.53.206.47
+...
+2021/06/17 15:39:30 Signer msg1 added
+```
+
+Now we add the next signer and this will be the one joining the group,
+note how automation stage changed:
+```
+$CMD conf-set tsigkey-msat1tsig2 ...tsig-secret...
+$CMD conf-set signer-tsigkey:msg2 msat1tsig2
+$CMD signer-add msat1.catch22.se. msg2 ns1.msg2.catch22.se. 13.53.34.31
+...
+2021/06/17 15:43:09 Signer msg2 added
+2021/06/17 15:43:09 Automation for msat1.catch22.se. now join-sync-dnskeys
+```
+
+Now we can run `status` to just check that it can query all server, don't
+worry about all the "missing" right now but look at what it found in `msg1`,
+`msg2` and the parent:
+```
+$CMD status msat1.catch22.se.
+...
+2021/06/17 15:43:36 msg1: found DNSKEY 257 3 13 nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 15:43:36 msg1: found DNSKEY 256 3 13 cVsbobWK6RCkVVdmhisDNgor0oRsYyjhv300B9Xdfx7j+WOuAjEEbvt08sAU7u+DSpHE88t8+SGDoefO3DvufQ==
+2021/06/17 15:43:36 msg1: found NS ns1.msg1.catch22.se.
+2021/06/17 15:43:36 msg2: found DNSKEY 257 3 13 oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 15:43:36 msg2: found DNSKEY 256 3 13 Hmva5+2gzldmznimU5dYnIKYUHAwmROXhrqcxS33eiE2VEnWDJWCrwjjTVxtPzQzcrEXUm4qfx+AqCZR1zVQdw==
+2021/06/17 15:43:36 msg2: found NS ns1.msg2.catch22.se.
+2021/06/17 15:43:36 Check sync status of msg1 DNSKEYs
+2021/06/17 15:43:36 DNSKEY missing in msg2: cVsbobWK6RCkVVdmhisDNgor0oRsYyjhv300B9Xdfx7j+WOuAjEEbvt08sAU7u+DSpHE88t8+SGDoefO3DvufQ==
+2021/06/17 15:43:36 Check sync status of msg2 DNSKEYs
+2021/06/17 15:43:36 DNSKEY missing in msg1: Hmva5+2gzldmznimU5dYnIKYUHAwmROXhrqcxS33eiE2VEnWDJWCrwjjTVxtPzQzcrEXUm4qfx+AqCZR1zVQdw==
+2021/06/17 15:43:36 Check sync status of msg1 CDSes
+2021/06/17 15:43:36 CDS missing for KSK: nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 15:43:36 CDS missing for KSK: oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 15:43:36 Check sync status of msg2 CDSes
+2021/06/17 15:43:36 CDS missing for KSK: nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 15:43:36 CDS missing for KSK: oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 15:43:36 Check sync status of msg1 CDNSKEYs
+2021/06/17 15:43:36 CDNSKEY missing for KSK: nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 15:43:36 CDNSKEY missing for KSK: oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 15:43:36 Check sync status of msg2 CDNSKEYs
+2021/06/17 15:43:36 CDNSKEY missing for KSK: nNKWCP5WcfkgC391ZCaUs5yYggwiB21U+teHyJZj2c+8lrwSfp5ENr99EwqkMp4kfHWRb7/M6sVevp9yISyPlA==
+2021/06/17 15:43:36 CDNSKEY missing for KSK: oVlyvr3PcPsLxLnMYcsUrvOQ+fQOoqgT927RUB4Sk0Sc7MG3D14/QBvA3k7+I1G2ho2oUU5LIkt1PZmaOZAOkQ==
+2021/06/17 15:43:36 Check sync status of msg1 NSes
+2021/06/17 15:43:36 NS missing: ns1.msg2.catch22.se.
+2021/06/17 15:43:36 Check sync status of msg2 NSes
+2021/06/17 15:43:36 NS missing: ns1.msg1.catch22.se.
+2021/06/17 15:43:36 Check sync status of NSes for leaving signers
+2021/06/17 15:43:36 Check sync status of parent 13.48.238.90:53
+2021/06/17 15:43:36   found DS 38959 13 2 ce45ee0f2869965a7ec55140d662c7469ea41d50028fbeed6fe1e2f2f92e5ac2
+2021/06/17 15:43:36   DS needs removal: 38959 13 2 ce45ee0f2869965a7ec55140d662c7469ea41d50028fbeed6fe1e2f2f92e5ac2
+2021/06/17 15:43:36   found NS ns1.msg1.catch22.se.
+2021/06/17 15:43:36   Missing NS: ns1.msg2.catch22.se.
+```
+
+If you reload the dashboard you will also see that the group has appeared.
+
+To start the automation run the following:
+```
+$CMD automate-start msat1.catch22.se.
+...
+2021/06/17 15:45:55 Starting automation for msat1.catch22.se.
+```
+You can also enable autostart of automation, see command `automate-autostart`.
+
+The automation will now progress for the group, you can view the progress in
+the console.
+
+Once the automation hits `join-parent-ds-synced`, `join-parent-ns-synced`,
+`leave-parent-ns-synced` or `leave-parent-ds-synced` it will wait for the
+parent's DS/NS records to be updated based on the signers CDS/CDNSKEY/CSYNC.
+If there is no automation at the parent you'll need to do this manually to
+progress.
+
+There are also two waiting stages `join-wait-ds` and `leave-wait-ns`, these
+can be fast-forwarded by setting the wait time to the past. See the stepping
+automation example above for how that is done.
+
+Once the group is `ready` you can mark `msg2` as leaving signer and follow
+the automation for when a signers is to be removed.
+
+```
+$CMD signer-mark-leave msg2
+...
+2021/06/17 15:55:53 Signer msg2 now marked as leaving
+2021/06/17 15:55:53 Automation for msat1.catch22.se. now leave-sync-nses
+```
+
+Then once again when the group is `ready` the `msg2` signer can be removed:
+```
+$CMD signer-remove msg2
+...
+2021/06/17 15:58:59 Signer msg2 removed
+```

--- a/README.md
+++ b/README.md
@@ -1,19 +1,80 @@
 # multi-signer-controller
 Control of a DNSSEC multi-signer group
 
-## Notes
-
-- Pick-up time for CDS/CDNSKEY on .ch may be up to one day / 24 hours
-
 # Configuration
 
-This is a list of current things that can be configured with `conf-set`:
-- `tsigkey-<name> <value>`: Add a TSIG key with the <name> and it's secret <value>
-- `desectoken-<name> <value>`: Add a deSEC.io token with the <name> and it's secret <value>
-- `signer-csk:<name> yes`: Indicate that the signer <name> is using a CSK
-- `signer-type:<name> <type>`: Set which <type> of signer <name> is, valid types are: nsupdate, desec
-- `signer-tsigkey:<name> <keyname>`: Set which TSIG key <keyname> that signer <name> should use
-- `signer-desec:<name> <tokenname>`: Set which deSEC token <tokenname> that signer <name> should use
+All configuration option values are either a `string` or an array of `string`.
+
+Current list of configuration options:
+- `groups`: An array of all multi-signer groups as FQDNs
+- `signers:<fqdn>`: An array of all signer names in a group.
+- `signer:<name>`: The `<host|ip>:port` of the authority name-server of a signer.
+- `signer-group:<name>`: The FQDN of the group a signer is part of.
+- `signer-type:<name>`: The type of Updater to use for the signer, default `nsupdate`.
+- `signer-ns:<name>`: The FQDN of the NS for a signer.
+- `signer-tsigkey:<name>`: The name of the TSIG key to use.
+- `signer-desec:<name>`: The name of the deSEC.io token to use.
+- `signer-leaving:<name>`: Exists if the signer is leaving the group.
+- `parent:<fqdn>`: The `<host|ip>:port` of the parent of a group.
+- `group-ttl:<fqdn>`: The TTL to use when creating new resource records for a group.
+- `group-dnskeys-synced:<fqdn>`: Exists if the DNSKEYs are synced within a group.
+- `group-cdscdnskeys-synced:<fqdn>`: Exists if the CDS/CDNSKEYs are synced within a group.
+- `group-nses-synced:<fqdn>`: Exists if the NSes are synced within a group.
+- `group-parent-ds-synced:<fqdn>`: Exists if the parent's DS is in sync with the group.
+- `group-parent-ns-synced:<fqdn>`: Exists if the parent's NS is in sync with the group.
+- `group-wait-ds:<fqdn>`: An RFC3399 date that exists if the group is waiting for DS records to propagate.
+- `group-wait-ns:<fqdn>`: An RFC3399 date that exists if the group is waiting for NS records to propagate.
+- `automate-stage:<fqdn>`: The current stage of the automation.
+- `automate-error:<fqdn>`: Exists if the automation ran into an error, if so it contains the string of an `error`.
+- `dnskey-origin:<dnskey>`: Set during sync when new DNSKEYs are detected, will contain the signer it was seen in.
+- `ns-origin:<ns fqdn>`: Set during sync when new NSes are detected, will contain the signer it was seen in.
+- `tsigkey-<name>`: The secret of a TSIG key.
+- `desectoken-<name>`: The secret of a deSEC.io token.
+- `debug-updater`: Set to `yes` to enable debug output of updaters.
+
+# Updaters
+
+To update the signers there are different kinds of updaters, using the
+`Updater` interface.
+
+Available updaters:
+- `nsupdate`: Uses dynamic updates to change zone information, requires a valid TSIG key to be configured.
+- `desec`: Uses deSEC.io API, not implemented yet.
+
+# Automation Stages
+
+Following automation stages exists.
+
+- `ready`: The group is ready for to receive changes.
+- `manual`: Can be used to mark a group as manually changed.
+- `error`: The automation encountered an error, see command `automate-error`.
+
+- `join-sync-dnskeys`: A new signer has joined and the DNSKEYs needs to be synced.
+- `join-dnskeys-synced`: Check that the DNSKEYs are in sync.
+- `join-sync-cdscdnskeys`: The CDS/CDNSKEYs needs to be created/synced.
+- `join-cdscdnskeys-synced`: Check that the CDS/CDNSKEYs are in sync.
+- `join-parent-ds-synced`: Check that the parent's DS are in sync.
+- `join-remove-cdscdnskeys`: Remove CDS/CDNSKEYs.
+- `join-wait-ds`: Wait for DS to propagate.
+- `join-sync-nses`: The NSes needs to be created/synced.
+- `join-nses-synced`: Check that the NSes are in sync.
+- `join-add-csync`: Add CSYNC.
+- `join-parent-ns-synced`: Check that the parent's NS are in sync.
+- `join-remove-csync`: Remove CSYNC.
+
+- `leave-sync-nses`: A signer is leaving and the NSes needs to be synced.
+- `leave-nses-synced`: Check that the NSes are in sync.
+- `leave-add-csync`: Add CSYNC.
+- `leave-parent-ns-synced`: Check that the parent's NS are in sync.
+- `leave-remove-csync`: Remove CSYNC.
+- `leave-wait-ns`: Wait for NS to propagate.
+- `leave-sync-dnskeys`: The DNSKEYs needs to be removed/synced.
+- `leave-dnskeys-synced`: Check that the DNSKEYs are in sync.
+- `leave-sync-cdscdnskeys`: The CDS/CDNSKEYs needs to be created/synced.
+- `leave-cdscdnskeys-synced`: Check that the CDS/CDNSKEYs are in sync.
+- `leave-parent-ds-synced`: Check that the parent's DS are in sync.
+- `leave-remove-cdscdnskeys`: Remove CDS/CDNSKEYs.
+
 
 # Runtime
 
@@ -26,6 +87,9 @@ see all runtime options by using `-help`.
 started another *multi-signer-controller* can communicate with that daemon
 by using `-remote`.
 
+When running as daemon you can also enable the web-based status interface
+by specifying a HTTP listening address and port using `-http`.
+
 # Commands
 
 All commands help and required parameters can be view using the `help`
@@ -33,60 +97,14 @@ command (without dash).
 
 # Example: How to run
 
-**TODO** Update run example!
-
-First we set a short-cut for the base of the command for this example:
-
-```
-CMD="./multi-signer-controller -conf example.conf"
-```
-
-Now we configure the TSIG and deSEC.io secrets we will use for each signer:
-
-```
-$CMD conf-set tsigkey-tsig asecret==
-$CMD conf-set desectoken-desec anothersecret
-```
-
-Then we create a new signer group:
-
-```
-$CMD group-add example.com.
-```
-
-Add the first signer and set it to use TSIG:
-
-```
-$CMD signer-add example.com. A 127.0.0.2
-$CMD conf-set signer-tsigkey:A tsig
-```
-
-Add the second signer and set it to use deSEC.io as a CSK:
-
-```
-$CMD signer-add example.com. B 127.0.0.3
-$CMD conf-set signer-desec:B desec
-$CMD conf-set signer-csk:B yes
-```
-
-Now we can check the status of the signer group:
-
-```
-$CMD status example.com.
-```
-
-And sync the DNSKEYs between the signers (Note: this step is still WIP):
-
-```
-$CMD sync-dnskey example.com.
-```
+See `EXAMPLE.md`.
 
 # local go
 
 ```
 mkdir -p go/1.16.5; wget -O - https://storage.googleapis.com/golang/go1.16.5.linux-amd64.tar.gz | tar -C go/1.16.5 -zxv
 export GOROOT="$HOME/go/1.16.5/go" GOPATH="$HOME/go"
-export PATH="$PATH:$GOROOT"
+export PATH="$PATH:$GOROOT/bin"
 ```
 
 # build
@@ -99,3 +117,4 @@ make
 # Known Issues
 
 - TSIG keys hardcoded to HMAC-SHA256
+- deSEC.io support not implemented yet

--- a/add_cmd.go
+++ b/add_cmd.go
@@ -2,17 +2,15 @@ package main
 
 import (
     "fmt"
-    "time"
+    "strconv"
 
     "github.com/miekg/dns"
 )
 
 func init() {
     Command["add-csync"] = AddCsyncCmd
-    Command["add-ns"] = AddNsCmd
 
     CommandHelp["add-csync"] = "Add CSYNC records on all signers for a group, requires <fqdn>"
-    CommandHelp["add-ns"] = "Add a custom NS to all signers in a group, requires <fqdn> <ns fqdn to add>"
 }
 
 func AddCsyncCmd(args []string, remote bool, output *[]string) error {
@@ -22,6 +20,11 @@ func AddCsyncCmd(args []string, remote bool, output *[]string) error {
 
     if !Config.Exists("signers:" + args[0]) {
         return fmt.Errorf("group %s has no signers", args[0])
+    }
+
+    ttl, err := strconv.Atoi(Config.Get("group-ttl:"+args[0], "300"))
+    if err != nil {
+        ttl = 300
     }
 
     signers := Config.ListGet("signers:" + args[0])
@@ -47,119 +50,17 @@ func AddCsyncCmd(args []string, remote bool, output *[]string) error {
             }
 
             csync := new(dns.CSYNC)
-            csync.Hdr = dns.RR_Header{Name: args[0], Rrtype: dns.TypeCSYNC, Class: dns.ClassINET, Ttl: 300}
+            csync.Hdr = dns.RR_Header{Name: args[0], Rrtype: dns.TypeCSYNC, Class: dns.ClassINET, Ttl: uint32(ttl)}
             csync.Serial = soa.Serial
             csync.Flags = 3
             csync.TypeBitMap = []uint16{dns.TypeA, dns.TypeNS, dns.TypeAAAA}
 
-            m = new(dns.Msg)
-            m.SetUpdate(args[0])
-            m.Insert([]dns.RR{csync})
-
-            *output = append(*output, m.String())
-
-            stype := Config.Get("signer-type:"+signer, "nsupdate")
-
-            switch stype {
-            case "nsupdate":
-                tsigkey := Config.Get("signer-tsigkey:"+signer, "")
-                if tsigkey == "" {
-                    *output = append(*output, fmt.Sprintf("Missing signer %s TSIG key, can't sync", signer))
-                    continue
-                }
-
-                secret := Config.Get("tsigkey-"+tsigkey, "")
-                if secret == "" {
-                    *output = append(*output, fmt.Sprintf("Missing TSIG key %s, can't sync %s", tsigkey, signer))
-                    continue
-                }
-
-                m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
-
-                c := new(dns.Client)
-                c.TsigSecret = map[string]string{tsigkey + ".": secret}
-                in, rtt, err := c.Exchange(m, ip)
-                if err != nil {
-                    return err
-                }
-
-                *output = append(*output, fmt.Sprintf("Insert took %v", rtt))
-                *output = append(*output, in.String())
-
-                *output = append(*output, fmt.Sprintf("  Added CSYNC to %s", signer))
-                break
-
-            default:
-                return fmt.Errorf("Unknown signer type %s for %s", stype, signer)
-            }
-
-            break
-        }
-    }
-
-    return nil
-}
-
-func AddNsCmd(args []string, remote bool, output *[]string) error {
-    if len(args) < 2 {
-        return fmt.Errorf("requires <fqdn> <ns fqdn to add>")
-    }
-
-    if !Config.Exists("signers:" + args[0]) {
-        return fmt.Errorf("group %s has no signers", args[0])
-    }
-
-    signers := Config.ListGet("signers:" + args[0])
-
-    ns := new(dns.NS)
-    ns.Hdr = dns.RR_Header{Name: args[0], Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300}
-    ns.Ns = args[1]
-
-    m := new(dns.Msg)
-    m.SetUpdate(args[0])
-    m.Insert([]dns.RR{ns})
-
-    *output = append(*output, m.String())
-
-    for _, signer := range signers {
-        ip := Config.Get("signer:"+signer, "")
-        if ip == "" {
-            *output = append(*output, fmt.Sprintf("No ip|host for signer %s(???), can't sync it", signer))
-            continue
-        }
-        stype := Config.Get("signer-type:"+signer, "nsupdate")
-
-        switch stype {
-        case "nsupdate":
-            tsigkey := Config.Get("signer-tsigkey:"+signer, "")
-            if tsigkey == "" {
-                *output = append(*output, fmt.Sprintf("Missing signer %s TSIG key, can't sync", signer))
-                continue
-            }
-
-            secret := Config.Get("tsigkey-"+tsigkey, "")
-            if secret == "" {
-                *output = append(*output, fmt.Sprintf("Missing TSIG key %s, can't sync %s", tsigkey, signer))
-                continue
-            }
-
-            m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
-
-            c := new(dns.Client)
-            c.TsigSecret = map[string]string{tsigkey + ".": secret}
-            in, rtt, err := c.Exchange(m, ip)
-            if err != nil {
+            updater := GetUpdater(Config.Get("signer-type:"+signer, "nsupdate"))
+            if err := updater.Update(args[0], signer, &[][]dns.RR{[]dns.RR{csync}}, nil, output); err != nil {
                 return err
             }
-
-            *output = append(*output, fmt.Sprintf("Insert took %v", rtt))
-            *output = append(*output, in.String())
-
-            *output = append(*output, fmt.Sprintf("  Added NS to %s", signer))
+            *output = append(*output, fmt.Sprintf("  Added CSYNC to %s", signer))
             break
-
-        default:
-            return fmt.Errorf("Unknown signer type %s for %s", stype, signer)
         }
     }
 

--- a/automate_cmd.go
+++ b/automate_cmd.go
@@ -1,0 +1,595 @@
+package main
+
+import (
+    "fmt"
+    "log"
+    "time"
+)
+
+const AutomateReady = "ready"
+const AutomateManual = "manual"
+const AutomateError = "error"
+
+const AutomateJoinSyncDnskeys = "join-sync-dnskeys"
+const AutomateJoinDnskeysSynced = "join-dnskeys-synced"
+const AutomateJoinSyncCdscdnskeys = "join-sync-cdscdnskeys"
+const AutomateJoinCdscdnskeysSynced = "join-cdscdnskeys-synced"
+const AutomateJoinParentDsSynced = "join-parent-ds-synced"
+const AutomateJoinRemoveCdscdnskeys = "join-remove-cdscdnskeys"
+const AutomateJoinWaitDs = "join-wait-ds"
+const AutomateJoinSyncNses = "join-sync-nses"
+const AutomateJoinNsesSynced = "join-nses-synced"
+const AutomateJoinAddCsync = "join-add-csync"
+const AutomateJoinParentNsSynced = "join-parent-ns-synced"
+const AutomateJoinRemoveCsync = "join-remove-csync"
+
+const AutomateLeaveSyncNses = "leave-sync-nses"
+const AutomateLeaveNsesSynced = "leave-nses-synced"
+const AutomateLeaveAddCsync = "leave-add-csync"
+const AutomateLeaveParentNsSynced = "leave-parent-ns-synced"
+const AutomateLeaveRemoveCsync = "leave-remove-csync"
+const AutomateLeaveWaitNs = "leave-wait-ns"
+const AutomateLeaveSyncDnskeys = "leave-sync-dnskeys"
+const AutomateLeaveDnskeysSynced = "leave-dnskeys-synced"
+const AutomateLeaveSyncCdscdnskeys = "leave-sync-cdscdnskeys"
+const AutomateLeaveCdscdnskeysSynced = "leave-cdscdnskeys-synced"
+const AutomateLeaveParentDsSynced = "leave-parent-ds-synced"
+const AutomateLeaveRemoveCdscdnskeys = "leave-remove-cdscdnskeys"
+
+type automation struct {
+    Group   string
+    Running bool
+    Stop    bool
+}
+
+var Automation map[string]*automation
+
+func init() {
+    Automation = make(map[string]*automation)
+
+    Command["automate-step"] = AutomateStepCmd
+    Command["automate-start"] = AutomateStartCmd
+    Command["automate-stop"] = AutomateStopCmd
+    Command["automate-error"] = AutomateErrorCmd
+    Command["automate-clear-error"] = AutomateClearErrorCmd
+    Command["automate-autostart"] = AutomateAutostartCmd
+    Command["automate-no-autostart"] = AutomateNoAutostartCmd
+
+    CommandHelp["automate-step"] = "Run one step of automation for a group, requires <fqdn>"
+    CommandHelp["automate-start"] = "Start automation for a group, requires <fqdn> (only in daemon mode)"
+    CommandHelp["automate-stop"] = "Stop automation for a group, requires <fqdn> (only in daemon mode)"
+    CommandHelp["automate-error"] = "Show if automation for a group ran into an error, requires <fqdn>"
+    CommandHelp["automate-clear-error"] = "Clear the automation error for a group and continue, requires <fqdn> <next step>"
+    CommandHelp["automate-autostart"] = "Set automation autostart for a group, requires <fqdn>"
+    CommandHelp["automate-no-autostart"] = "Remove automation autostart for a group, requires <fqdn>"
+}
+
+func AutomateStepCmd(args []string, remote bool, output *[]string) error {
+    if len(args) < 1 {
+        return fmt.Errorf("requires <fqdn>")
+    }
+
+    stage := Config.Get("automate-stage:"+args[0], "")
+
+    signers := make(map[string]bool)
+    for _, s := range Config.ListGet("signers:" + args[0]) {
+        if Config.Get("signer-leaving:"+s, "") == "" {
+            signers[s] = false
+        } else {
+            signers[s] = true
+        }
+    }
+    WsStatus(args[0], stage, signers)
+
+    switch stage {
+    case AutomateReady:
+        *output = append(*output, "Nothing to do for "+args[0])
+        return nil
+
+    case AutomateError:
+        *output = append(*output, "Error exist for "+args[0])
+        return nil
+
+    case AutomateJoinSyncDnskeys:
+        err := SyncDnskeyCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinDnskeysSynced)
+
+    case AutomateJoinDnskeysSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-dnskeys-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "DNSKEYs not synced yet for "+args[0])
+            Config.Set("automate-stage:"+args[0], AutomateJoinSyncDnskeys)
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinSyncCdscdnskeys)
+
+    case AutomateJoinSyncCdscdnskeys:
+        err := SyncCdscdnskeysCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinCdscdnskeysSynced)
+
+    case AutomateJoinCdscdnskeysSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-cdscdnskeys-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "CDS/CDNSKEYs not synced yet for "+args[0])
+            Config.Set("automate-stage:"+args[0], AutomateJoinSyncCdscdnskeys)
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinParentDsSynced)
+
+    case AutomateJoinParentDsSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-parent-ds-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "Parent DS not synced yet for "+args[0])
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinRemoveCdscdnskeys)
+
+    case AutomateJoinRemoveCdscdnskeys:
+        err := RemoveCdscdnskeysCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinWaitDs)
+
+    case AutomateJoinWaitDs:
+        wait_until := Config.Get("group-wait-ds:"+args[0], "")
+        if wait_until == "" {
+            err := WaitDsCmd(args, remote, output)
+            if err != nil {
+                Config.Set("automate-error:"+args[0], err.Error())
+                Config.Set("automate-stage:"+args[0], AutomateError)
+                return err
+            }
+        }
+        until, err := time.Parse(time.RFC3339, Config.Get("group-wait-ds:"+args[0], ""))
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+
+        if time.Now().Before(until) {
+            *output = append(*output, fmt.Sprintf("Wait until %s (%s)", until.String(), time.Until(until).String()))
+            WsWaitUntil(args[0], time.Until(until).String())
+            return nil
+        }
+        WsWaitUntil(args[0], "done")
+        Config.Remove("group-wait-ds:" + args[0])
+        Config.Set("automate-stage:"+args[0], AutomateJoinSyncNses)
+
+    case AutomateJoinSyncNses:
+        err := SyncNsCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinNsesSynced)
+
+    case AutomateJoinNsesSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-nses-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "NSes not synced yet for "+args[0])
+            Config.Set("automate-stage:"+args[0], AutomateJoinSyncNses)
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinAddCsync)
+
+    case AutomateJoinAddCsync:
+        err := AddCsyncCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinParentNsSynced)
+
+    case AutomateJoinParentNsSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-parent-ns-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "Parent NS not synced yet for "+args[0])
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateJoinRemoveCsync)
+
+    case AutomateJoinRemoveCsync:
+        err := RemoveCsyncCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateReady)
+
+    case AutomateLeaveSyncNses:
+        err := SyncNsCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveNsesSynced)
+
+    case AutomateLeaveNsesSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-nses-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "NSes not synced yet for "+args[0])
+            Config.Set("automate-stage:"+args[0], AutomateLeaveSyncNses)
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveAddCsync)
+
+    case AutomateLeaveAddCsync:
+        err := AddCsyncCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveParentNsSynced)
+
+    case AutomateLeaveParentNsSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-parent-ns-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "Parent NS not synced yet for "+args[0])
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveRemoveCsync)
+
+    case AutomateLeaveRemoveCsync:
+        err := RemoveCsyncCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveWaitNs)
+
+    case AutomateLeaveWaitNs:
+        wait_until := Config.Get("group-wait-ns:"+args[0], "")
+        if wait_until == "" {
+            err := WaitNsCmd(args, remote, output)
+            if err != nil {
+                Config.Set("automate-error:"+args[0], err.Error())
+                Config.Set("automate-stage:"+args[0], AutomateError)
+                return err
+            }
+        }
+        until, err := time.Parse(time.RFC3339, Config.Get("group-wait-ns:"+args[0], ""))
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+
+        if time.Now().Before(until) {
+            *output = append(*output, fmt.Sprintf("Wait until %s (%s)", until.String(), time.Until(until).String()))
+            WsWaitUntil(args[0], time.Until(until).String())
+            return nil
+        }
+        WsWaitUntil(args[0], "done")
+        Config.Remove("group-wait-ns:" + args[0])
+        Config.Set("automate-stage:"+args[0], AutomateLeaveSyncDnskeys)
+
+    case AutomateLeaveSyncDnskeys:
+        err := SyncDnskeyCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveDnskeysSynced)
+
+    case AutomateLeaveDnskeysSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-dnskeys-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "DNSKEYs not synced yet for "+args[0])
+            Config.Set("automate-stage:"+args[0], AutomateLeaveSyncDnskeys)
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveSyncCdscdnskeys)
+
+    case AutomateLeaveSyncCdscdnskeys:
+        err := SyncCdscdnskeysCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveCdscdnskeysSynced)
+
+    case AutomateLeaveCdscdnskeysSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-cdscdnskeys-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "CDS/CDNSKEYs not synced yet for "+args[0])
+            Config.Set("automate-stage:"+args[0], AutomateLeaveSyncCdscdnskeys)
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveParentDsSynced)
+
+    case AutomateLeaveParentDsSynced:
+        err := StatusCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        if synced := Config.Get("group-parent-ds-synced:"+args[0], ""); synced != "yes" {
+            *output = append(*output, "Parent DS not synced yet for "+args[0])
+            return nil
+        }
+        Config.Set("automate-stage:"+args[0], AutomateLeaveRemoveCdscdnskeys)
+
+    case AutomateLeaveRemoveCdscdnskeys:
+        err := RemoveCdscdnskeysCmd(args, remote, output)
+        if err != nil {
+            Config.Set("automate-error:"+args[0], err.Error())
+            Config.Set("automate-stage:"+args[0], AutomateError)
+            return err
+        }
+        Config.Set("automate-stage:"+args[0], AutomateReady)
+
+    default:
+        return fmt.Errorf("Unknown automate stage %s", stage)
+    }
+
+    *output = append(*output, "Automate step "+stage+" success, next stage "+Config.Get("automate-stage:"+args[0], "<unknown>"))
+
+    signers = make(map[string]bool)
+    for _, s := range Config.ListGet("signers:" + args[0]) {
+        if Config.Get("signer-leaving:"+s, "") == "" {
+            signers[s] = false
+        } else {
+            signers[s] = true
+        }
+    }
+    WsStatus(args[0], Config.Get("automate-stage:"+args[0], "<unknown>"), signers)
+
+    return nil
+}
+
+func AutomateAutostart() {
+    l := Config.ListGet("automate-autostart")
+    for _, g := range l {
+        output := []string{}
+        err := AutomateStartCmd([]string{g}, true, &output)
+        if err != nil {
+            log.Fatal(err)
+        }
+        for _, o := range output {
+            log.Println("Automate autostart:", o)
+        }
+    }
+}
+
+func AutomateStartCmd(args []string, remote bool, output *[]string) error {
+    if !remote {
+        return ErrOnlyRemoteCall
+    }
+
+    if len(args) < 1 {
+        return fmt.Errorf("requires <fqdn>")
+    }
+
+    if _, ok := Automation[args[0]]; ok {
+        return fmt.Errorf("Automation for group %s already running", args[0])
+    }
+
+    if !Config.ListEntryExists("groups", args[0]) {
+        return fmt.Errorf("group %s does not exist", args[0])
+    }
+
+    *output = append(*output, "Starting automation for "+args[0])
+
+    a := &automation{
+        Group:   args[0],
+        Running: true,
+        Stop:    false,
+    }
+    Automation[args[0]] = a
+
+    go func(a *automation) {
+        log.Println("Automating", a.Group)
+        for !a.Stop {
+            time.Sleep(10 * time.Second)
+
+            DaemonLock.Lock()
+
+            args := []string{a.Group}
+            output := []string{}
+            err := AutomateStepCmd(args, false, &output)
+            if err != nil {
+                WsConsole("Automation step failed: " + err.Error())
+                log.Println("Automation step failed:", err.Error())
+                DaemonLock.Unlock()
+                continue
+            }
+            if cerr := Config.Store(DaemonConf); cerr != nil {
+                log.Fatal(cerr)
+            }
+            DaemonLock.Unlock()
+            // log.Println("Automation step successful for", a.Group)
+            for _, o := range output {
+                WsConsole("Automate " + a.Group + ": " + o)
+                log.Println("Automate "+a.Group+":", o)
+            }
+        }
+        log.Println("Ending automation for", a.Group)
+        a.Running = false
+    }(a)
+
+    return nil
+}
+
+func AutomateStopCmd(args []string, remote bool, output *[]string) error {
+    if !remote {
+        return ErrOnlyRemoteCall
+    }
+
+    if len(args) < 1 {
+        return fmt.Errorf("requires <fqdn>")
+    }
+
+    if _, ok := Automation[args[0]]; !ok {
+        return fmt.Errorf("Automation for group %s is not running", args[0])
+    }
+
+    *output = append(*output, "Stopping automation for "+args[0])
+    Automation[args[0]].Stop = true
+
+    return nil
+}
+
+func AutomateErrorCmd(args []string, remote bool, output *[]string) error {
+    if len(args) < 1 {
+        return fmt.Errorf("requires <fqdn>")
+    }
+
+    stage := Config.Get("automate-stage:"+args[0], "")
+    switch stage {
+    case "":
+        return fmt.Errorf("No automation stage found for %s", args[0])
+    case AutomateError:
+        error := Config.Get("automate-error:"+args[0], "<unknown>")
+        *output = append(*output, "Error during automation for "+args[0]+": "+error)
+    default:
+        *output = append(*output, "No automation error for "+args[0])
+    }
+
+    return nil
+}
+
+func AutomateClearErrorCmd(args []string, remote bool, output *[]string) error {
+    if len(args) < 2 {
+        return fmt.Errorf("requires <fqdn> <next stage>")
+    }
+
+    stage := Config.Get("automate-stage:"+args[0], "")
+    switch stage {
+    case "":
+        return fmt.Errorf("No automation stage found for %s", args[0])
+    case AutomateError:
+    default:
+        *output = append(*output, "No automation error for "+args[0])
+        return nil
+    }
+
+    switch args[1] {
+    case AutomateReady:
+    case AutomateJoinSyncDnskeys:
+    case AutomateJoinDnskeysSynced:
+    case AutomateJoinSyncCdscdnskeys:
+    case AutomateJoinCdscdnskeysSynced:
+    case AutomateJoinParentDsSynced:
+    case AutomateJoinRemoveCdscdnskeys:
+    case AutomateJoinWaitDs:
+    case AutomateJoinSyncNses:
+    case AutomateJoinNsesSynced:
+    case AutomateJoinAddCsync:
+    case AutomateJoinParentNsSynced:
+    case AutomateJoinRemoveCsync:
+    case AutomateLeaveSyncNses:
+    case AutomateLeaveNsesSynced:
+    case AutomateLeaveAddCsync:
+    case AutomateLeaveParentNsSynced:
+    case AutomateLeaveRemoveCsync:
+    case AutomateLeaveWaitNs:
+    case AutomateLeaveSyncDnskeys:
+    case AutomateLeaveDnskeysSynced:
+    case AutomateLeaveSyncCdscdnskeys:
+    case AutomateLeaveCdscdnskeysSynced:
+    case AutomateLeaveParentDsSynced:
+    case AutomateLeaveRemoveCdscdnskeys:
+    default:
+        return fmt.Errorf("Invalid next stage %s", args[1])
+    }
+
+    Config.Remove("automate-error:" + args[0])
+    Config.Set("automate-stage:"+args[0], args[1])
+    *output = append(*output, "Clear automation error for "+args[0]+" and set next stage to "+args[1])
+
+    return nil
+}
+
+func AutomateAutostartCmd(args []string, remote bool, output *[]string) error {
+    if len(args) < 1 {
+        return fmt.Errorf("requires <fqdn>")
+    }
+
+    if !Config.ListEntryExists("groups", args[0]) {
+        return fmt.Errorf("group %s does not exist", args[0])
+    }
+
+    Config.ListAdd("automate-autostart", args[0], false)
+    *output = append(*output, "Autostart enabled for "+args[0])
+
+    return nil
+}
+
+func AutomateNoAutostartCmd(args []string, remote bool, output *[]string) error {
+    if len(args) < 1 {
+        return fmt.Errorf("requires <fqdn>")
+    }
+
+    Config.ListRemove("automate-autostart", args[0])
+    *output = append(*output, "Autostart disabled for "+args[0])
+
+    return nil
+}

--- a/cmd.go
+++ b/cmd.go
@@ -10,3 +10,4 @@ var Command = make(map[string]CmdFunc)
 var CommandHelp = make(map[string]string)
 
 var ErrNoRemoteCall = fmt.Errorf("Can not be called remotely")
+var ErrOnlyRemoteCall = fmt.Errorf("Can only be called remotely")

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
     "encoding/json"
     "fmt"
     "io/ioutil"
+    "strings"
     "sync"
 )
 
@@ -80,23 +81,18 @@ func (c *config) Remove(name string) bool {
     return true
 }
 
-// type ConfigChangeFunc func(string) string
-//
-// func (c *config) Change(name, _default string, f ConfigChangeFunc) {
-//     c.m.Lock()
-//     defer c.m.Unlock()
-//
-//     v, ok := c.conf[name]
-//     if !ok {
-//         v = _default
-//     }
-//
-//     v = f(v)
-//
-//     c.conf[name] = value
-//
-//     c.changed = true
-// }
+func (c *config) PrefixKeys(prefix string) []string {
+    c.m.Lock()
+    defer c.m.Unlock()
+
+    keys := []string{}
+    for k, _ := range c.conf {
+        if strings.HasPrefix(k, prefix) {
+            keys = append(keys, k)
+        }
+    }
+    return keys
+}
 
 func (c *config) ListExists(name string) bool {
     c.m.RLock()

--- a/config_cmd.go
+++ b/config_cmd.go
@@ -8,6 +8,9 @@ func init() {
     Command["conf-list"] = ConfigListCmd
     CommandHelp["conf-list"] = "List all configured options and their current values"
 
+    Command["conf-get"] = ConfigGetCmd
+    CommandHelp["conf-get"] = "Get a config option, requires <name>"
+
     Command["conf-set"] = ConfigSetCmd
     CommandHelp["conf-set"] = "Set a config option, requires <name> <value>"
 }
@@ -20,6 +23,16 @@ func ConfigListCmd(args []string, remote bool, output *[]string) error {
     for k, v := range Config.conf {
         *output = append(*output, fmt.Sprintf("  %s: %v", k, v))
     }
+
+    return nil
+}
+
+func ConfigGetCmd(args []string, remote bool, output *[]string) error {
+    if len(args) < 1 {
+        return fmt.Errorf("Missing <name>")
+    }
+
+    *output = append(*output, fmt.Sprintf("Config %s: %s", args[0], Config.Get(args[0], "")))
 
     return nil
 }

--- a/daemon_cmd.go
+++ b/daemon_cmd.go
@@ -6,21 +6,40 @@ import (
     "net"
     "net/http"
     "net/rpc"
+    "strings"
+    "sync"
 )
+
+var IsDaemon bool
+var DaemonConf string
+var DaemonLock sync.Mutex
 
 type Rpc struct {
 }
 
 func (r *Rpc) Call(args []string, reply *[]string) error {
+    DaemonLock.Lock()
+    defer DaemonLock.Unlock()
+
     cmd, ok := Command[args[0]]
     if !ok {
         log.Println("Invalid call:", args[0])
         return fmt.Errorf("Command does not exist: ", args[0])
     }
 
-    log.Println("Calling command", args[0])
+    log.Println("Calling command", args)
+    WsConsole("Calling command " + strings.Join(args, " "))
     if err := cmd(args[1:], true, reply); err != nil {
+        WsConsole("Command " + args[0] + " error: " + err.Error())
         return fmt.Errorf("Command ", args[0], " error: ", err)
+    }
+    for _, r := range *reply {
+        WsConsole(" " + r)
+        log.Println("", r)
+    }
+
+    if err := Config.Store(DaemonConf); err != nil {
+        log.Fatal(err)
     }
 
     return nil
@@ -40,6 +59,8 @@ func DaemonCmd(args []string, remote bool, output *[]string) error {
         return fmt.Errorf("server/ip and port for RPC required")
     }
 
+    IsDaemon = true
+
     r := new(Rpc)
     rpc.Register(r)
     rpc.HandleHTTP()
@@ -48,6 +69,7 @@ func DaemonCmd(args []string, remote bool, output *[]string) error {
         return fmt.Errorf("listen error:", e)
     }
     log.Println("Listening for RPC on", l.Addr().String())
+    AutomateAutostart()
     http.Serve(l, nil)
 
     return nil

--- a/desec_updater.go
+++ b/desec_updater.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+    "fmt"
+
+    "github.com/miekg/dns"
+)
+
+type DesecUpdater struct {
+}
+
+func init() {
+    Updaters["desec"] = &DesecUpdater{}
+}
+
+func (d *DesecUpdater) Update(fqdn, signer string, inserts, removes *[][]dns.RR, output *[]string) error {
+    return fmt.Errorf("deSEC.io support not implemented")
+}
+
+func (d *DesecUpdater) RemoveRRset(fqdn, signer string, rrsets [][]dns.RR, output *[]string) error {
+    return fmt.Errorf("deSEC.io support not implemented")
+}
+
+// token := Config.Get("signer-desec:"+osigner, "")
+// if token == "" {
+//     *output = append(*output, fmt.Sprintf("Missing signer %s deSEC token, can't sync %s keys to it", osigner, signer))
+//     continue
+// }
+//
+// secret := Config.Get("desectoken-"+token, "")
+// if secret == "" {
+//     *output = append(*output, fmt.Sprintf("Missing deSEC token %s, can't sync %s keys to %s", token, signer, osigner))
+//     continue
+// }
+//
+// zone := args[0]
+// if zone[len(zone)-1] == '.' {
+//     zone = zone[:len(zone)-1]
+// }
+//
+// rrset := &DesecRRset{
+//     Subname: "",
+//     Type:    "DNSKEY",
+//     Records: []string{fmt.Sprintf("%d %d %d %s", key.Flags, key.Protocol, key.Algorithm, key.PublicKey)},
+//     Ttl:     ttl,
+// }
+//
+// *output = append(*output, "POST:")
+// *output = append(*output, fmt.Sprintf("  %v", rrset))
+//
+// body, err := json.Marshal(rrset)
+// if err != nil {
+//     return err
+// }
+// *output = append(*output, string(body))
+//
+// req, err := http.NewRequest("POST", fmt.Sprintf("https://desec.io/api/v1/domains/%s/rrsets/", zone), bytes.NewReader(body))
+// if err != nil {
+//     return err
+// }
+// req.Header.Add("Authorization", fmt.Sprintf("Token %s", secret))
+// req.Header.Add("Content-Type", "application/json")
+//
+// client := &http.Client{}
+// resp, err := client.Do(req)
+// if err != nil {
+//     return err
+// }
+// defer resp.Body.Close()
+// body, err = ioutil.ReadAll(resp.Body)
+// if err != nil {
+//     return err
+// }
+//
+// rrset = &DesecRRset{}
+// json.Unmarshal(body, &rrset)
+// *output = append(*output, "Response:")
+// *output = append(*output, resp.Status)
+// *output = append(*output, fmt.Sprintf("  %v", rrset))
+// break

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/google/uuid v1.2.0
 	github.com/miekg/dns v1.1.42
+	github.com/gorilla/websocket v1.4.2
 )

--- a/group_cmd.go
+++ b/group_cmd.go
@@ -29,6 +29,7 @@ func GroupAddCmd(args []string, remote bool, output *[]string) error {
         *output = append(*output, fmt.Sprintf("Group %s added", args[0]))
 
         Config.Set("parent:"+args[0], args[1])
+        Config.Set("automate-stage:"+args[0], AutomateReady)
     } else {
         *output = append(*output, fmt.Sprintf("Group %s already exists", args[0]))
     }

--- a/home.html
+++ b/home.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-+0n0xVW2eSR5OomGNYDnhzAbDsOXxcvSN1TPprVMTNDbiYZCxYbOOl7+AMvyTG2x" crossorigin="anonymous">
+</head>
+<body>
+<main>
+<div class="d-flex flex-row">
+<div class="vh-100 d-flex flex-column flex-shrink-0 p-3 text-white bg-dark" style="width: 280px;">
+    <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none">
+        <span class="fs-4">Multi-Signer</span>
+    </a>
+    <hr>
+    <ul class="nav nav-pills flex-column mb-auto">
+        <li class="nav-item">
+            <a id="nav-dashboard" href="#" class="nav-link active">Dashboard</a>
+        </li>
+        <li>
+            <a id="nav-console" href="#" class="nav-link text-white">Console</a>
+        </li>
+    </ul>
+    <hr>
+    <span id="conn-status">Connecting...</span>
+</div>
+<div id="dashboard" class="m-2 d-flex flex-column">
+</div>
+<div id="console" class="p-2 d-flex flex-column d-none vh-100">
+    <div class="float-end">
+        <button type="button" class="btn btn-danger">Clear</button>
+        <button type="button" class="btn btn-secondary">Autoscroll: On</button>
+    </div>
+    <small class="mt-2 font-monospace overflow-auto mh-100">
+    </small>
+</div>
+</div>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+</body>
+<script>
+$(document).ready(function(){
+    var websocketConn, websocketConnect, updateGroup, updateWait;
+    var consoleAutoscroll = true;
+
+    var groups = {};
+    updateGroup = function(fqdn, stage, signers) {
+        var g = groups[fqdn];
+        if (!g) {
+            g = $('<div class="card"><h5 class="card-header"></h5><div class="card-body">Stage: <span></span><br/><div id="wait" class="d-none"></div>Signers: <span></span></div></div>');
+            $('.card-header', g).text(fqdn);
+            g.appendTo('#dashboard');
+            groups[fqdn] = g;
+        }
+
+        $('span:eq(0)', g).text(stage);
+
+        var signer_status = [];
+        for (var idx in signers) {
+            var signer = signers[idx];
+            signer_status.push(signer.name+(signer.leaving ? ' (leaving)' : ''));
+        }
+        signer_status.sort();
+        $('span:eq(1)', g).text(signer_status.join(', '));
+    };
+    updateWait = function(fqdn, wait) {
+        var g = groups[fqdn];
+        if (!g) {
+            return;
+        }
+        if (wait == "done") {
+            $('#wait', g).addClass('d-none');
+        } else {
+            $('#wait', g).removeClass('d-none');
+            $('#wait').text(wait);
+        }
+    };
+
+    websocketConnect = function(){
+        console.log("websocket: Connecting");
+        websocketConn = new WebSocket("ws"+(document.location.protocol=="https:"?"s":"")+"://" + document.location.host + "/ws");
+        websocketConn.onclose = function (evt) {
+            console.log("websocket: Connection closed");
+            $('#conn-status').text('Reconnecting...');
+            window.setTimeout(function(){ websocketConnect(); }, 2000);
+        };
+        websocketConn.onmessage = function (evt) {
+            var messages = evt.data.split('\n');
+            for (var i = 0; i < messages.length; i++) {
+                console.log("msg: "+messages[i]);
+                var m = $.parseJSON(messages[i]);
+
+                if (m.log) {
+                    m.log = m.log.replace("\n", "<br/>");
+                    $('<span></span><br/>').text(m.log).appendTo($('#console small'));
+                    if (consoleAutoscroll) {
+                        $('#console small').scrollTop($('#console small').prop('scrollHeight'));
+                    }
+                } else if (m.left) {
+                    updateWait(m.fqdn, m.left);
+                } else if (m.fqdn) {
+                    updateGroup(m.fqdn, m.stage, m.signers);
+                }
+            }
+        };
+        websocketConn.onopen = function () {
+            console.log("websocket: Connected");
+            $('#conn-status').text('Online');
+        };
+    };
+    websocketConnect();
+
+    $('#nav-dashboard').click(function(event){
+        event.preventDefault();
+        $('#nav-console').removeClass('active').addClass('text-white');
+        $(this).addClass('active').removeClass('text-white');
+        $('#console').addClass('d-none');
+        $('#dashboard').removeClass('d-none');
+    });
+    $('#nav-console').click(function(event){
+        event.preventDefault();
+        $('#nav-dashboard').removeClass('active').addClass('text-white');
+        $(this).addClass('active').removeClass('text-white');
+        $('#dashboard').addClass('d-none');
+        $('#console').removeClass('d-none');
+
+        if (consoleAutoscroll) {
+            $('#console small').scrollTop($('#console small').prop('scrollHeight'));
+        }
+    });
+    $('#console button:eq(0)').click(function(event){
+        event.preventDefault();
+        $('#console small').html('');
+    });
+    $('#console button:eq(1)').click(function(event){
+        event.preventDefault();
+        if (consoleAutoscroll) {
+            consoleAutoscroll = false;
+            $('#console button:eq(1)').text('Autoscroll: Off');
+        } else {
+            consoleAutoscroll = true;
+            $('#console button:eq(1)').text('Autoscroll: On');
+        }
+    });
+});
+</script>
+</html>

--- a/nsupdate_updater.go
+++ b/nsupdate_updater.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+    "fmt"
+    "time"
+
+    "github.com/miekg/dns"
+)
+
+type NsupdateUpdater struct {
+}
+
+func init() {
+    Updaters["nsupdate"] = &NsupdateUpdater{}
+}
+
+func (n *NsupdateUpdater) Update(fqdn, signer string, inserts, removes *[][]dns.RR, output *[]string) error {
+    inserts_len := 0
+    removes_len := 0
+    if inserts != nil {
+        for _, insert := range *inserts {
+            inserts_len += len(insert)
+        }
+    }
+    if removes != nil {
+        for _, remove := range *removes {
+            removes_len += len(remove)
+        }
+    }
+    if inserts_len == 0 && removes_len == 0 {
+        return fmt.Errorf("Inserts and removes empty, nothing to do")
+    }
+
+    ip := Config.Get("signer:"+signer, "")
+    if ip == "" {
+        return fmt.Errorf("No ip|host for signer %s", signer)
+    }
+
+    tsigkey := Config.Get("signer-tsigkey:"+signer, "")
+    if tsigkey == "" {
+        return fmt.Errorf("Missing signer %s TSIG key %s", signer, tsigkey)
+    }
+
+    secret := Config.Get("tsigkey-"+tsigkey, "")
+    if secret == "" {
+        return fmt.Errorf("Missing TSIG key secret for %s", tsigkey)
+    }
+
+    m := new(dns.Msg)
+    m.SetUpdate(fqdn)
+    if inserts != nil {
+        for _, insert := range *inserts {
+            m.Insert(insert)
+        }
+    }
+    if removes != nil {
+        for _, remove := range *removes {
+            m.Remove(remove)
+        }
+    }
+    m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
+
+    debug := false
+    if Config.Get("debug-updater", "") == "yes" {
+        debug = true
+    }
+
+    *output = append(*output, fmt.Sprintf("nsupdate: Sending inserts %d, removals %d to signer %s", inserts_len, removes_len, signer))
+    if debug {
+        *output = append(*output, m.String())
+    }
+
+    c := new(dns.Client)
+    c.TsigSecret = map[string]string{tsigkey + ".": secret}
+    in, rtt, err := c.Exchange(m, ip)
+    if err != nil {
+        return err
+    }
+
+    if debug {
+        *output = append(*output, in.String())
+    }
+    *output = append(*output, fmt.Sprintf("nsupdate: Update took %v, rcode %s", rtt, dns.RcodeToString[in.MsgHdr.Rcode]))
+
+    return nil
+}
+
+func (d *NsupdateUpdater) RemoveRRset(fqdn, signer string, rrsets [][]dns.RR, output *[]string) error {
+    rrsets_len := 0
+    for _, rrset := range rrsets {
+        rrsets_len += len(rrset)
+    }
+    if rrsets_len == 0 {
+        return fmt.Errorf("rrset(s) is empty, nothing to do")
+    }
+
+    ip := Config.Get("signer:"+signer, "")
+    if ip == "" {
+        return fmt.Errorf("No ip|host for signer %s", signer)
+    }
+
+    tsigkey := Config.Get("signer-tsigkey:"+signer, "")
+    if tsigkey == "" {
+        return fmt.Errorf("Missing signer %s TSIG key %s", signer, tsigkey)
+    }
+
+    secret := Config.Get("tsigkey-"+tsigkey, "")
+    if secret == "" {
+        return fmt.Errorf("Missing TSIG key secret for %s", tsigkey)
+    }
+
+    m := new(dns.Msg)
+    m.SetUpdate(fqdn)
+    for _, rrset := range rrsets {
+        m.RemoveRRset(rrset)
+    }
+    m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
+
+    debug := false
+    if Config.Get("debug-updater", "") == "yes" {
+        debug = true
+    }
+
+    *output = append(*output, fmt.Sprintf("nsupdate: Sending remove rrset(s) %d to signer %s", rrsets_len, signer))
+    if debug {
+        *output = append(*output, m.String())
+    }
+
+    c := new(dns.Client)
+    c.TsigSecret = map[string]string{tsigkey + ".": secret}
+    in, rtt, err := c.Exchange(m, ip)
+    if err != nil {
+        return err
+    }
+
+    if debug {
+        *output = append(*output, in.String())
+    }
+    *output = append(*output, fmt.Sprintf("nsupdate: Update took %v, rcode %s", rtt, dns.RcodeToString[in.MsgHdr.Rcode]))
+
+    return nil
+}

--- a/remove_cmd.go
+++ b/remove_cmd.go
@@ -2,22 +2,19 @@ package main
 
 import (
     "fmt"
-    "time"
 
     "github.com/miekg/dns"
 )
 
 func init() {
-    Command["remove-cdcdnskeys"] = RemoveCdcdnskeysCmd
+    Command["remove-cdscdnskeys"] = RemoveCdscdnskeysCmd
     Command["remove-csync"] = RemoveCsyncCmd
-    Command["remove-ns"] = RemoveNsCmd
 
-    CommandHelp["remove-cdcdnskeys"] = "Remove all CDS/CDNSKEYs from signers in a group, requires <fqdn>"
+    CommandHelp["remove-cdscdnskeys"] = "Remove all CDS/CDNSKEYs from signers in a group, requires <fqdn>"
     CommandHelp["remove-csync"] = "Remove all CSYNCs from signers in a group, requires <fqdn>"
-    CommandHelp["remove-ns"] = "Remove a custom NS from all signers in a group, requires <fqdn> <ns fqdn to remove>"
 }
 
-func RemoveCdcdnskeysCmd(args []string, remote bool, output *[]string) error {
+func RemoveCdscdnskeysCmd(args []string, remote bool, output *[]string) error {
     if len(args) < 1 {
         return fmt.Errorf("requires <fqdn>")
     }
@@ -34,53 +31,12 @@ func RemoveCdcdnskeysCmd(args []string, remote bool, output *[]string) error {
     cdnskey := new(dns.CDNSKEY)
     cdnskey.Hdr = dns.RR_Header{Name: args[0], Rrtype: dns.TypeCDNSKEY, Class: dns.ClassINET, Ttl: 0}
 
-    m := new(dns.Msg)
-    m.SetUpdate(args[0])
-    m.RemoveRRset([]dns.RR{cds})
-    m.RemoveRRset([]dns.RR{cdnskey})
-
-    *output = append(*output, m.String())
-
     for _, signer := range signers {
-        ip := Config.Get("signer:"+signer, "")
-        if ip == "" {
-            *output = append(*output, fmt.Sprintf("No ip|host for signer %s(???), can't sync it", signer))
-            continue
+        updater := GetUpdater(Config.Get("signer-type:"+signer, "nsupdate"))
+        if err := updater.RemoveRRset(args[0], signer, [][]dns.RR{[]dns.RR{cds}, []dns.RR{cdnskey}}, output); err != nil {
+            return err
         }
-        stype := Config.Get("signer-type:"+signer, "nsupdate")
-
-        switch stype {
-        case "nsupdate":
-            tsigkey := Config.Get("signer-tsigkey:"+signer, "")
-            if tsigkey == "" {
-                *output = append(*output, fmt.Sprintf("Missing signer %s TSIG key, can't sync", signer))
-                continue
-            }
-
-            secret := Config.Get("tsigkey-"+tsigkey, "")
-            if secret == "" {
-                *output = append(*output, fmt.Sprintf("Missing TSIG key %s, can't sync %s", tsigkey, signer))
-                continue
-            }
-
-            m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
-
-            c := new(dns.Client)
-            c.TsigSecret = map[string]string{tsigkey + ".": secret}
-            in, rtt, err := c.Exchange(m, ip)
-            if err != nil {
-                return err
-            }
-
-            *output = append(*output, fmt.Sprintf("Remove took %v", rtt))
-            *output = append(*output, in.String())
-
-            *output = append(*output, fmt.Sprintf("  Removed CD/CDNSKEYs from %s", signer))
-            break
-
-        default:
-            return fmt.Errorf("Unknown signer type %s for %s", stype, signer)
-        }
+        *output = append(*output, fmt.Sprintf("  Removed CDS/CDNSKEYs from %s", signer))
     }
 
     return nil
@@ -100,118 +56,12 @@ func RemoveCsyncCmd(args []string, remote bool, output *[]string) error {
     csync := new(dns.CSYNC)
     csync.Hdr = dns.RR_Header{Name: args[0], Rrtype: dns.TypeCSYNC, Class: dns.ClassINET, Ttl: 0}
 
-    m := new(dns.Msg)
-    m.SetUpdate(args[0])
-    m.RemoveRRset([]dns.RR{csync})
-
-    *output = append(*output, m.String())
-
     for _, signer := range signers {
-        ip := Config.Get("signer:"+signer, "")
-        if ip == "" {
-            *output = append(*output, fmt.Sprintf("No ip|host for signer %s(???), can't sync it", signer))
-            continue
+        updater := GetUpdater(Config.Get("signer-type:"+signer, "nsupdate"))
+        if err := updater.RemoveRRset(args[0], signer, [][]dns.RR{[]dns.RR{csync}}, output); err != nil {
+            return err
         }
-        stype := Config.Get("signer-type:"+signer, "nsupdate")
-
-        switch stype {
-        case "nsupdate":
-            tsigkey := Config.Get("signer-tsigkey:"+signer, "")
-            if tsigkey == "" {
-                *output = append(*output, fmt.Sprintf("Missing signer %s TSIG key, can't sync", signer))
-                continue
-            }
-
-            secret := Config.Get("tsigkey-"+tsigkey, "")
-            if secret == "" {
-                *output = append(*output, fmt.Sprintf("Missing TSIG key %s, can't sync %s", tsigkey, signer))
-                continue
-            }
-
-            m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
-
-            c := new(dns.Client)
-            c.TsigSecret = map[string]string{tsigkey + ".": secret}
-            in, rtt, err := c.Exchange(m, ip)
-            if err != nil {
-                return err
-            }
-
-            *output = append(*output, fmt.Sprintf("Remove took %v", rtt))
-            *output = append(*output, in.String())
-
-            *output = append(*output, fmt.Sprintf("  Removed CSYNC from %s", signer))
-            break
-
-        default:
-            return fmt.Errorf("Unknown signer type %s for %s", stype, signer)
-        }
-    }
-
-    return nil
-}
-
-func RemoveNsCmd(args []string, remote bool, output *[]string) error {
-    if len(args) < 2 {
-        return fmt.Errorf("requires <fqdn> <ns fqdn to remove>")
-    }
-
-    if !Config.Exists("signers:" + args[0]) {
-        return fmt.Errorf("group %s has no signers", args[0])
-    }
-
-    signers := Config.ListGet("signers:" + args[0])
-
-    ns := new(dns.NS)
-    ns.Hdr = dns.RR_Header{Name: args[0], Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 0}
-    ns.Ns = args[1]
-
-    m := new(dns.Msg)
-    m.SetUpdate(args[0])
-    m.Remove([]dns.RR{ns})
-
-    *output = append(*output, m.String())
-
-    for _, signer := range signers {
-        ip := Config.Get("signer:"+signer, "")
-        if ip == "" {
-            *output = append(*output, fmt.Sprintf("No ip|host for signer %s(???), can't sync it", signer))
-            continue
-        }
-        stype := Config.Get("signer-type:"+signer, "nsupdate")
-
-        switch stype {
-        case "nsupdate":
-            tsigkey := Config.Get("signer-tsigkey:"+signer, "")
-            if tsigkey == "" {
-                *output = append(*output, fmt.Sprintf("Missing signer %s TSIG key, can't sync", signer))
-                continue
-            }
-
-            secret := Config.Get("tsigkey-"+tsigkey, "")
-            if secret == "" {
-                *output = append(*output, fmt.Sprintf("Missing TSIG key %s, can't sync %s", tsigkey, signer))
-                continue
-            }
-
-            m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
-
-            c := new(dns.Client)
-            c.TsigSecret = map[string]string{tsigkey + ".": secret}
-            in, rtt, err := c.Exchange(m, ip)
-            if err != nil {
-                return err
-            }
-
-            *output = append(*output, fmt.Sprintf("Remove took %v", rtt))
-            *output = append(*output, in.String())
-
-            *output = append(*output, fmt.Sprintf("  Removed NS from %s", signer))
-            break
-
-        default:
-            return fmt.Errorf("Unknown signer type %s for %s", stype, signer)
-        }
+        *output = append(*output, fmt.Sprintf("  Removed CSYNC from %s", signer))
     }
 
     return nil

--- a/signer_cmd.go
+++ b/signer_cmd.go
@@ -34,15 +34,29 @@ func SignerAddCmd(args []string, remote bool, output *[]string) error {
         return fmt.Errorf("group %s does not exist", args[0])
     }
 
+    stage := Config.Get("automate-stage:"+args[0], "")
+    if stage != AutomateReady && stage != AutomateManual {
+        return fmt.Errorf("group %s is not ready to have more signers (automate stage %s)", args[0], stage)
+    }
+
     if Config.Exists("signer:" + args[1]) {
         return fmt.Errorf("signer %s already exists", args[1])
     }
 
     Config.Set("signer:"+args[1], args[3])
     Config.Set("signer-ns:"+args[1], args[2])
+    Config.Set("signer-group:"+args[1], args[0])
     Config.ListAdd("signers:"+args[0], args[1], false)
 
     *output = append(*output, fmt.Sprintf("Signer %s added", args[1]))
+
+    if stage != AutomateManual {
+        l := Config.ListGet("signers:" + args[0])
+        if len(l) > 1 {
+            Config.Set("automate-stage:"+args[0], AutomateJoinSyncDnskeys)
+            *output = append(*output, fmt.Sprintf("Automation for %s now %s", args[0], AutomateJoinSyncDnskeys))
+        }
+    }
 
     return nil
 }
@@ -63,18 +77,43 @@ func SignerListCmd(args []string, remote bool, output *[]string) error {
 }
 
 func SignerRemoveCmd(args []string, remote bool, output *[]string) error {
-    if len(args) < 2 {
-        return fmt.Errorf("requires <group> <name>")
+    if len(args) < 1 {
+        return fmt.Errorf("requires <name>")
     }
 
-    if !Config.Exists("signer:" + args[1]) {
-        return fmt.Errorf("signer %s does not exists", args[1])
+    if !Config.Exists("signer:" + args[0]) {
+        return fmt.Errorf("signer %s does not exists", args[0])
     }
 
-    Config.ListRemove("signers:"+args[1], args[0])
+    if Config.Get("signer-leaving:"+args[0], "") != "yes" {
+        return fmt.Errorf("signer %s is not marked leaving", args[0])
+    }
+
+    group := Config.Get("signer-group:"+args[0], "")
+
+    if !Config.ListEntryExists("groups", group) {
+        return fmt.Errorf("group %s does not exist", group)
+    }
+
+    if Config.Get("automate-stage:"+group, "") != AutomateReady {
+        return fmt.Errorf("group %s is not in ready state", group)
+    }
+
+    Config.ListRemove("signers:"+group, args[0])
     Config.Remove("signer:" + args[0])
+    Config.Remove("signer-group:" + args[0])
+    ns := Config.Get("signer-ns:"+args[0], "")
+    Config.Remove("ns-origin:" + ns)
+    Config.Remove("signer-ns:" + args[0])
+    Config.Remove("signer-tsigkey:" + args[0])
+    for _, k := range Config.PrefixKeys("dnskey-origin:") {
+        if Config.Get(k, "") == args[0] {
+            Config.Remove(k)
+        }
+    }
+    Config.Remove("signer-leaving:" + args[0])
 
-    *output = append(*output, fmt.Sprintf("Signer %s removed", args[1]))
+    *output = append(*output, fmt.Sprintf("Signer %s removed", args[0]))
 
     return nil
 }
@@ -115,9 +154,31 @@ func SignerMarkLeaveCmd(args []string, remote bool, output *[]string) error {
     if !Config.Exists("signer:" + args[0]) {
         return fmt.Errorf("signer %s does not exist", args[0])
     }
+    group := Config.Get("signer-group:"+args[0], "")
+    if !Config.ListEntryExists("groups", group) {
+        return fmt.Errorf("group %s for signer does not exist", group)
+    }
+
+    if leaving := Config.Get("signer-leaving:"+args[0], ""); leaving == "yes" {
+        *output = append(*output, fmt.Sprintf("Signer %s already leaving", args[0]))
+        return nil
+    }
+
+    stage := Config.Get("automate-stage:"+group, "")
+    if stage != AutomateReady && stage != AutomateManual {
+        return fmt.Errorf("group %s is not ready for change (automate stage %s)", group, stage)
+    }
 
     Config.Set("signer-leaving:"+args[0], "yes")
     *output = append(*output, fmt.Sprintf("Signer %s now marked as leaving", args[0]))
+
+    if stage != AutomateManual {
+        l := Config.ListGet("signers:" + group)
+        if len(l) > 1 {
+            Config.Set("automate-stage:"+group, AutomateLeaveSyncNses)
+            *output = append(*output, fmt.Sprintf("Automation for %s now %s", group, AutomateLeaveSyncNses))
+        }
+    }
 
     return nil
 }
@@ -130,9 +191,31 @@ func SignerUnmarkLeaveCmd(args []string, remote bool, output *[]string) error {
     if !Config.Exists("signer:" + args[0]) {
         return fmt.Errorf("signer %s does not exist", args[0])
     }
+    group := Config.Get("signer-group:"+args[0], "")
+    if !Config.ListEntryExists("groups", group) {
+        return fmt.Errorf("group %s for signer does not exist", group)
+    }
+
+    if leaving := Config.Get("signer-leaving:"+args[0], ""); leaving != "yes" {
+        *output = append(*output, fmt.Sprintf("Signer %s is not leaving", args[0]))
+        return nil
+    }
+
+    stage := Config.Get("automate-stage:"+group, "")
+    if stage != AutomateReady && stage != AutomateManual {
+        return fmt.Errorf("group %s is not ready for change (automate stage %s)", group, stage)
+    }
 
     Config.Remove("signer-leaving:" + args[0])
     *output = append(*output, fmt.Sprintf("Signer %s is no longer marked as leaving", args[0]))
+
+    if stage != AutomateManual {
+        l := Config.ListGet("signers:" + group)
+        if len(l) > 1 {
+            Config.Set("automate-stage:"+group, AutomateJoinSyncDnskeys)
+            *output = append(*output, fmt.Sprintf("Automation for %s now %s", group, AutomateJoinSyncDnskeys))
+        }
+    }
 
     return nil
 }

--- a/sync_cmd.go
+++ b/sync_cmd.go
@@ -2,23 +2,18 @@ package main
 
 import (
     "fmt"
-    "time"
-
-    "bytes"
-    "encoding/json"
-    "io/ioutil"
-    "net/http"
+    "strconv"
 
     "github.com/miekg/dns"
 )
 
 func init() {
     Command["sync-dnskey"] = SyncDnskeyCmd
-    Command["sync-cdcdnskeys"] = SyncCdcdnskeysCmd
+    Command["sync-cdscdnskeys"] = SyncCdscdnskeysCmd
     Command["sync-ns"] = SyncNsCmd
 
     CommandHelp["sync-dnskey"] = "Sync DNSKEYs between signers in a group, requires <fqdn>"
-    CommandHelp["sync-cdcdnskeys"] = "Create CDS/CDNSKEYs from DNSKEYs and sync them between signers in a group, requires <fqdn>"
+    CommandHelp["sync-cdscdnskeys"] = "Create CDS/CDNSKEYs from DNSKEYs and sync them between signers in a group, requires <fqdn>"
     CommandHelp["sync-ns"] = "Sync NSes between signers in a group, requires <fqdn>"
 }
 
@@ -53,8 +48,6 @@ func SyncDnskeyCmd(args []string, remote bool, output *[]string) error {
 
         dnskeys[signer] = []*dns.DNSKEY{}
 
-        csk := Config.Get("signer-csk:"+signer, "")
-
         for _, a := range r.Answer {
             dnskey, ok := a.(*dns.DNSKEY)
             if !ok {
@@ -63,20 +56,18 @@ func SyncDnskeyCmd(args []string, remote bool, output *[]string) error {
 
             dnskeys[signer] = append(dnskeys[signer], dnskey)
 
-            if f := dnskey.Flags & 0x101; f == 256 || csk != "" {
+            if f := dnskey.Flags & 0x101; f == 256 {
                 Config.SetIfNotExists("dnskey-origin:"+fmt.Sprintf("%d-%d-%s", dnskey.Protocol, dnskey.Algorithm, dnskey.PublicKey), signer)
             }
         }
     }
 
     for signer, keys := range dnskeys {
-        csk := Config.Get("signer-csk:"+signer, "")
-
         leaving := Config.Get("signer-leaving:"+signer, "")
         if leaving != "" {
             *output = append(*output, fmt.Sprintf("Signer %s is leaving, removing it's DNSKEYs from others", signer))
             for _, key := range keys {
-                if f := key.Flags & 0x101; f == 256 || csk != "" {
+                if f := key.Flags & 0x101; f == 256 {
                     // check that it's our key
                     if Config.Get("dnskey-origin:"+fmt.Sprintf("%d-%d-%s", key.Protocol, key.Algorithm, key.PublicKey), "") != signer {
                         continue
@@ -90,13 +81,6 @@ func SyncDnskeyCmd(args []string, remote bool, output *[]string) error {
                         if leaving := Config.Get("signer-leaving:"+osigner, ""); leaving != "" {
                             continue
                         }
-
-                        ip := Config.Get("signer:"+osigner, "")
-                        if ip == "" {
-                            *output = append(*output, fmt.Sprintf("No ip|host for signer %s(???), can't sync it", osigner))
-                            continue
-                        }
-                        stype := Config.Get("signer-type:"+osigner, "nsupdate")
 
                         found := false
                         for _, okey := range okeys {
@@ -114,43 +98,11 @@ func SyncDnskeyCmd(args []string, remote bool, output *[]string) error {
                             }
                         }
                         if found {
-                            switch stype {
-                            case "nsupdate":
-                                tsigkey := Config.Get("signer-tsigkey:"+osigner, "")
-                                if tsigkey == "" {
-                                    *output = append(*output, fmt.Sprintf("Missing signer %s TSIG key, can't sync %s keys to it", osigner, signer))
-                                    continue
-                                }
-
-                                secret := Config.Get("tsigkey-"+tsigkey, "")
-                                if secret == "" {
-                                    *output = append(*output, fmt.Sprintf("Missing TSIG key %s, can't sync %s keys to %s", tsigkey, signer, osigner))
-                                    continue
-                                }
-
-                                m := new(dns.Msg)
-                                m.SetUpdate(args[0])
-                                m.Remove([]dns.RR{key})
-                                m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
-
-                                *output = append(*output, m.String())
-
-                                c := new(dns.Client)
-                                c.TsigSecret = map[string]string{tsigkey + ".": secret}
-                                in, rtt, err := c.Exchange(m, ip)
-                                if err != nil {
-                                    return err
-                                }
-
-                                *output = append(*output, fmt.Sprintf("Remove took %v", rtt))
-                                *output = append(*output, in.String())
-
-                                *output = append(*output, fmt.Sprintf("  Removed DNSKEY from %s", osigner))
-                                break
-
-                            default:
-                                return fmt.Errorf("Unknown signer type %s for %s", stype, osigner)
+                            updater := GetUpdater(Config.Get("signer-type:"+osigner, "nsupdate"))
+                            if err := updater.Update(args[0], osigner, nil, &[][]dns.RR{[]dns.RR{key}}, output); err != nil {
+                                return err
                             }
+                            *output = append(*output, fmt.Sprintf("  Removed DNSKEY from %s", osigner))
                         }
                     }
                 }
@@ -161,7 +113,7 @@ func SyncDnskeyCmd(args []string, remote bool, output *[]string) error {
         *output = append(*output, fmt.Sprintf("Syncing %s DNSKEYs", signer))
 
         for _, key := range keys {
-            if f := key.Flags & 0x101; f == 256 || csk != "" {
+            if f := key.Flags & 0x101; f == 256 {
                 *output = append(*output, fmt.Sprintf("- %s", key.PublicKey))
 
                 for osigner, okeys := range dnskeys {
@@ -171,13 +123,6 @@ func SyncDnskeyCmd(args []string, remote bool, output *[]string) error {
                     if leaving := Config.Get("signer-leaving:"+osigner, ""); leaving != "" {
                         continue
                     }
-
-                    ip := Config.Get("signer:"+osigner, "")
-                    if ip == "" {
-                        *output = append(*output, fmt.Sprintf("No ip|host for signer %s(???), can't sync it", osigner))
-                        continue
-                    }
-                    stype := Config.Get("signer-type:"+osigner, "nsupdate")
 
                     found := false
                     for _, okey := range okeys {
@@ -196,102 +141,11 @@ func SyncDnskeyCmd(args []string, remote bool, output *[]string) error {
                     }
 
                     if !found {
-                        switch stype {
-                        case "nsupdate":
-                            tsigkey := Config.Get("signer-tsigkey:"+osigner, "")
-                            if tsigkey == "" {
-                                *output = append(*output, fmt.Sprintf("Missing signer %s TSIG key, can't sync %s keys to it", osigner, signer))
-                                continue
-                            }
-
-                            secret := Config.Get("tsigkey-"+tsigkey, "")
-                            if secret == "" {
-                                *output = append(*output, fmt.Sprintf("Missing TSIG key %s, can't sync %s keys to %s", tsigkey, signer, osigner))
-                                continue
-                            }
-
-                            m := new(dns.Msg)
-                            m.SetUpdate(args[0])
-                            m.Insert([]dns.RR{key})
-                            m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
-
-                            *output = append(*output, m.String())
-
-                            c := new(dns.Client)
-                            c.TsigSecret = map[string]string{tsigkey + ".": secret}
-                            in, rtt, err := c.Exchange(m, ip)
-                            if err != nil {
-                                return err
-                            }
-
-                            *output = append(*output, fmt.Sprintf("Insert took %v", rtt))
-                            *output = append(*output, in.String())
-
-                            *output = append(*output, fmt.Sprintf("  Added DNSKEY to %s", osigner))
-                            break
-
-                        case "desec":
-                            token := Config.Get("signer-desec:"+osigner, "")
-                            if token == "" {
-                                *output = append(*output, fmt.Sprintf("Missing signer %s deSEC token, can't sync %s keys to it", osigner, signer))
-                                continue
-                            }
-
-                            secret := Config.Get("desectoken-"+token, "")
-                            if secret == "" {
-                                *output = append(*output, fmt.Sprintf("Missing deSEC token %s, can't sync %s keys to %s", token, signer, osigner))
-                                continue
-                            }
-
-                            zone := args[0]
-                            if zone[len(zone)-1] == '.' {
-                                zone = zone[:len(zone)-1]
-                            }
-
-                            rrset := &DesecRRset{
-                                Subname: "",
-                                Type:    "DNSKEY",
-                                Records: []string{fmt.Sprintf("%d %d %d %s", key.Flags, key.Protocol, key.Algorithm, key.PublicKey)},
-                                Ttl:     3600,
-                            }
-
-                            *output = append(*output, "POST:")
-                            *output = append(*output, fmt.Sprintf("  %v", rrset))
-
-                            body, err := json.Marshal(rrset)
-                            if err != nil {
-                                return err
-                            }
-                            *output = append(*output, string(body))
-
-                            req, err := http.NewRequest("POST", fmt.Sprintf("https://desec.io/api/v1/domains/%s/rrsets/", zone), bytes.NewReader(body))
-                            if err != nil {
-                                return err
-                            }
-                            req.Header.Add("Authorization", fmt.Sprintf("Token %s", secret))
-                            req.Header.Add("Content-Type", "application/json")
-
-                            client := &http.Client{}
-                            resp, err := client.Do(req)
-                            if err != nil {
-                                return err
-                            }
-                            defer resp.Body.Close()
-                            body, err = ioutil.ReadAll(resp.Body)
-                            if err != nil {
-                                return err
-                            }
-
-                            rrset = &DesecRRset{}
-                            json.Unmarshal(body, &rrset)
-                            *output = append(*output, "Response:")
-                            *output = append(*output, resp.Status)
-                            *output = append(*output, fmt.Sprintf("  %v", rrset))
-                            break
-
-                        default:
-                            return fmt.Errorf("Unknown signer type %s for %s", stype, osigner)
+                        updater := GetUpdater(Config.Get("signer-type:"+osigner, "nsupdate"))
+                        if err := updater.Update(args[0], osigner, &[][]dns.RR{[]dns.RR{key}}, nil, output); err != nil {
+                            return err
                         }
+                        *output = append(*output, fmt.Sprintf("  Added DNSKEY to %s", osigner))
                     } else {
                         *output = append(*output, fmt.Sprintf("  Key exist in %s", osigner))
                     }
@@ -303,7 +157,7 @@ func SyncDnskeyCmd(args []string, remote bool, output *[]string) error {
     return nil
 }
 
-func SyncCdcdnskeysCmd(args []string, remote bool, output *[]string) error {
+func SyncCdscdnskeysCmd(args []string, remote bool, output *[]string) error {
     if len(args) < 1 {
         return fmt.Errorf("requires <fqdn>")
     }
@@ -359,57 +213,16 @@ func SyncCdcdnskeysCmd(args []string, remote bool, output *[]string) error {
         }
     }
 
-    m := new(dns.Msg)
-    m.SetUpdate(args[0])
-    m.Insert(cdses)
-    m.Insert(cdnskeys)
-
-    *output = append(*output, m.String())
-
     for _, signer := range signers {
         if leaving := Config.Get("signer-leaving:"+signer, ""); leaving != "" {
             continue
         }
 
-        ip := Config.Get("signer:"+signer, "")
-        if ip == "" {
-            *output = append(*output, fmt.Sprintf("No ip|host for signer %s(???), can't sync it", signer))
-            continue
+        updater := GetUpdater(Config.Get("signer-type:"+signer, "nsupdate"))
+        if err := updater.Update(args[0], signer, &[][]dns.RR{cdses, cdnskeys}, nil, output); err != nil {
+            return err
         }
-        stype := Config.Get("signer-type:"+signer, "nsupdate")
-
-        switch stype {
-        case "nsupdate":
-            tsigkey := Config.Get("signer-tsigkey:"+signer, "")
-            if tsigkey == "" {
-                *output = append(*output, fmt.Sprintf("Missing signer %s TSIG key, can't sync", signer))
-                continue
-            }
-
-            secret := Config.Get("tsigkey-"+tsigkey, "")
-            if secret == "" {
-                *output = append(*output, fmt.Sprintf("Missing TSIG key %s, can't sync %s", tsigkey, signer))
-                continue
-            }
-
-            m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
-
-            c := new(dns.Client)
-            c.TsigSecret = map[string]string{tsigkey + ".": secret}
-            in, rtt, err := c.Exchange(m, ip)
-            if err != nil {
-                return err
-            }
-
-            *output = append(*output, fmt.Sprintf("Insert took %v", rtt))
-            *output = append(*output, in.String())
-
-            *output = append(*output, fmt.Sprintf("  Added CD/CDNSKEYs to %s", signer))
-            break
-
-        default:
-            return fmt.Errorf("Unknown signer type %s for %s", stype, signer)
-        }
+        *output = append(*output, fmt.Sprintf("  Added CDS/CDNSKEYs to %s", signer))
     }
 
     return nil
@@ -422,6 +235,11 @@ func SyncNsCmd(args []string, remote bool, output *[]string) error {
 
     if !Config.Exists("signers:" + args[0]) {
         return fmt.Errorf("group %s has no signers", args[0])
+    }
+
+    ttl, err := strconv.Atoi(Config.Get("group-ttl:"+args[0], "300"))
+    if err != nil {
+        ttl = 300
     }
 
     signers := Config.ListGet("signers:" + args[0])
@@ -488,61 +306,18 @@ func SyncNsCmd(args []string, remote bool, output *[]string) error {
         }
         if _, ok := nsmap[ns]; !ok {
             rr := new(dns.NS)
-            rr.Hdr = dns.RR_Header{Name: args[0], Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300}
+            rr.Hdr = dns.RR_Header{Name: args[0], Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: uint32(ttl)}
             rr.Ns = ns
             nsset = append(nsset, rr)
         }
     }
 
-    m := new(dns.Msg)
-    m.SetUpdate(args[0])
-    m.Insert(nsset)
-    if len(nsrem) > 0 {
-        m.Remove(nsrem)
-    }
-
-    *output = append(*output, m.String())
-
     for _, signer := range signers {
-        ip := Config.Get("signer:"+signer, "")
-        if ip == "" {
-            *output = append(*output, fmt.Sprintf("No ip|host for signer %s(???), can't sync it", signer))
-            continue
+        updater := GetUpdater(Config.Get("signer-type:"+signer, "nsupdate"))
+        if err := updater.Update(args[0], signer, &[][]dns.RR{nsset}, &[][]dns.RR{nsrem}, output); err != nil {
+            return err
         }
-        stype := Config.Get("signer-type:"+signer, "nsupdate")
-
-        switch stype {
-        case "nsupdate":
-            tsigkey := Config.Get("signer-tsigkey:"+signer, "")
-            if tsigkey == "" {
-                *output = append(*output, fmt.Sprintf("Missing signer %s TSIG key, can't sync", signer))
-                continue
-            }
-
-            secret := Config.Get("tsigkey-"+tsigkey, "")
-            if secret == "" {
-                *output = append(*output, fmt.Sprintf("Missing TSIG key %s, can't sync %s", tsigkey, signer))
-                continue
-            }
-
-            m.SetTsig(tsigkey+".", dns.HmacSHA256, 300, time.Now().Unix())
-
-            c := new(dns.Client)
-            c.TsigSecret = map[string]string{tsigkey + ".": secret}
-            in, rtt, err := c.Exchange(m, ip)
-            if err != nil {
-                return err
-            }
-
-            *output = append(*output, fmt.Sprintf("Insert took %v", rtt))
-            *output = append(*output, in.String())
-
-            *output = append(*output, fmt.Sprintf("  Added NSes to %s", signer))
-            break
-
-        default:
-            return fmt.Errorf("Unknown signer type %s for %s", stype, signer)
-        }
+        *output = append(*output, fmt.Sprintf("  Add/rem'ed NSes to %s", signer))
     }
 
     return nil

--- a/updater.go
+++ b/updater.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+    "log"
+
+    "github.com/miekg/dns"
+)
+
+type Updater interface {
+    Update(fqdn, signer string, inserts, removes *[][]dns.RR, output *[]string) error
+    RemoveRRset(fqdn, signer string, rrsets [][]dns.RR, output *[]string) error
+}
+
+var Updaters map[string]Updater = make(map[string]Updater)
+
+func GetUpdater(type_ string) Updater {
+    updater, ok := Updaters[type_]
+    if !ok {
+        log.Fatal("No updater type", type_)
+    }
+    return updater
+}

--- a/websocket.go
+++ b/websocket.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "log"
+    "net/http"
+    "sync"
+    "time"
+
+    "github.com/gorilla/websocket"
+)
+
+const (
+    writeWait      = 10 * time.Second
+    pongWait       = 60 * time.Second
+    pingPeriod     = (pongWait * 9) / 10
+    maxMessageSize = 512
+)
+
+var (
+    newline = []byte{'\n'}
+    space   = []byte{' '}
+)
+
+var upgrader = websocket.Upgrader{
+    ReadBufferSize:  1024,
+    WriteBufferSize: 1024,
+}
+
+type Client struct {
+    conn *websocket.Conn
+    send chan []byte
+}
+
+var Clients map[string]*Client
+var ClientsLock sync.Mutex
+
+func init() {
+    Clients = make(map[string]*Client)
+}
+
+type console struct {
+    Log string `json:"log"`
+}
+
+func WsConsole(s string) {
+    b, err := json.Marshal(&console{Log: s})
+    if err != nil {
+        log.Fatal(err)
+    }
+    ClientsLock.Lock()
+    for _, c := range Clients {
+        c.send <- b
+    }
+    ClientsLock.Unlock()
+}
+
+type signerStatus struct {
+    Name    string `json:"name"`
+    Leaving bool   `json:"leaving"`
+}
+type groupStatus struct {
+    Fqdn    string         `json:"fqdn"`
+    Stage   string         `json:"stage"`
+    Signers []signerStatus `json:"signers"`
+}
+
+func WsStatus(fqdn, stage string, signers map[string]bool) {
+    status := &groupStatus{Fqdn: fqdn, Stage: stage}
+    for s, l := range signers {
+        status.Signers = append(status.Signers, signerStatus{Name: s, Leaving: l})
+    }
+    b, err := json.Marshal(status)
+    if err != nil {
+        log.Fatal(err)
+    }
+    ClientsLock.Lock()
+    for _, c := range Clients {
+        c.send <- b
+    }
+    ClientsLock.Unlock()
+}
+
+type waitUntil struct {
+    Fqdn string `json:"fqdn"`
+    Left string `json:"left"`
+}
+
+func WsWaitUntil(fqdn, left string) {
+    b, err := json.Marshal(&waitUntil{Fqdn: fqdn, Left: left})
+    if err != nil {
+        log.Fatal(err)
+    }
+    ClientsLock.Lock()
+    for _, c := range Clients {
+        c.send <- b
+    }
+    ClientsLock.Unlock()
+}
+
+func (c *Client) readPump() {
+    defer func() {
+        log.Println("lost websocket connection", c.conn.RemoteAddr().String())
+        c.conn.Close()
+        ClientsLock.Lock()
+        delete(Clients, c.conn.RemoteAddr().String())
+        ClientsLock.Unlock()
+    }()
+    c.conn.SetReadLimit(maxMessageSize)
+    c.conn.SetReadDeadline(time.Now().Add(pongWait))
+    c.conn.SetPongHandler(func(string) error { c.conn.SetReadDeadline(time.Now().Add(pongWait)); return nil })
+    for {
+        _, message, err := c.conn.ReadMessage()
+        if err != nil {
+            if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+                log.Printf("error: %v", err)
+            }
+            break
+        }
+        message = bytes.TrimSpace(bytes.Replace(message, newline, space, -1))
+        // c.hub.broadcast <- message
+    }
+}
+
+func (c *Client) writePump() {
+    ticker := time.NewTicker(pingPeriod)
+    defer func() {
+        ticker.Stop()
+        c.conn.Close()
+    }()
+    for {
+        select {
+        case message, ok := <-c.send:
+            c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+            if !ok {
+                c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+                return
+            }
+
+            w, err := c.conn.NextWriter(websocket.TextMessage)
+            if err != nil {
+                return
+            }
+            w.Write(message)
+
+            n := len(c.send)
+            for i := 0; i < n; i++ {
+                w.Write(newline)
+                w.Write(<-c.send)
+            }
+
+            if err := w.Close(); err != nil {
+                return
+            }
+        case <-ticker.C:
+            c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+            if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+                return
+            }
+        }
+    }
+}
+
+func serveWs(w http.ResponseWriter, r *http.Request) {
+    conn, err := upgrader.Upgrade(w, r, nil)
+    if err != nil {
+        log.Println(err)
+        return
+    }
+    client := &Client{conn: conn, send: make(chan []byte, 256)}
+    log.Println("new websocket connection from", conn.RemoteAddr().String())
+    ClientsLock.Lock()
+    Clients[conn.RemoteAddr().String()] = client
+    ClientsLock.Unlock()
+
+    go client.writePump()
+    go client.readPump()
+
+    DaemonLock.Lock()
+    for _, g := range Config.ListGet("groups") {
+        signers := make(map[string]bool)
+        for _, s := range Config.ListGet("signers:" + g) {
+            if Config.Get("signer-leaving:"+s, "") == "" {
+                signers[s] = false
+            } else {
+                signers[s] = true
+            }
+        }
+        WsStatus(g, Config.Get("automate-stage:"+g, ""), signers)
+    }
+    DaemonLock.Unlock()
+}


### PR DESCRIPTION
- Add run example for stepping automation and daemonized full automation
- Add list of all configuration options
- Add notes of all automation stages
- Remove custom NS add/remove commands
- Add automation of join/leave signer
- Add `automate-step`
- Add `automate-start`
- Add `automate-stop`
- Add `automate-error`
- Add `automate-clear-error`
- Add `automate-autostart`
- Add `automate-no-autostart`
- Add `Config.PrefixKeys()`
- Add `conf-get`
- `daemon`: Add lock on `Call()` to protect execution and configuration change
- Add `Updater` interface
- Add skeleton for deSEC.io updater
- Add HTTP status dashboard and console
- Add nsupdate updater, dynamic updates using TSIG keys
- Fix typo in `remove-cdscdnskeys` command
- Fix typo in `sync-cdscdnskeys` command
- Remove CSK check, wasn't fully supported
- Use `group-ttl` config for created resource records